### PR TITLE
Coroner Buff

### DIFF
--- a/limited/coroner
+++ b/limited/coroner
@@ -2,5 +2,5 @@
 __Basics__
 Upon every death, the Coroner is informed how that participant died. 
 __Details__
-The Coroner will be told how every player that dies died, and if multiple causes of death are present, then all causes will be revealed to the Coroner. 
+The Coroner will be told the cause of death for every dead player, and if multiple causes of death are present, then all causes will be revealed to the Coroner. 
 The Coroner is only told the name of roles, and never the name of a player.

--- a/limited/coroner
+++ b/limited/coroner
@@ -3,4 +3,4 @@ __Basics__
 Upon every death, the Coroner is informed how that participant died. 
 __Details__
 The Coroner will be told the cause of death for every dead player, and if multiple causes of death are present, then all causes will be revealed to the Coroner. 
-The Coroner is only told the name of roles, and never the name of a player.
+The Coroner is only told the name of roles, and never the name of a player. The Coroner is not affected by any disguises.

--- a/limited/coroner
+++ b/limited/coroner
@@ -1,6 +1,6 @@
 **Coroner** | Townsfolk Investigative
 __Basics__
-Once per day, the Coroner can check how a dead participant died. 
+Upon every death, the Coroner is informed how that participant died. 
 __Details__
-Each day, the Coroner can inspect a dead participant. The Coroner will be told how that specific player died, if multiple causes of death were present, then all causes will be revealed to the Coroner. 
-The Coroner is only told the name of roles, and never the name of a player. Inspecting a player is an immediate ability. 
+The Coroner will be told how every player that dies died, and if multiple causes of death are present, then all causes will be revealed to the Coroner. 
+The Coroner is only told the name of roles, and never the name of a player.


### PR DESCRIPTION
Coroner was removed because it was too weak. Making it a passive power would be a buff and would make it more useful.