### PR TITLE
Oracle not affected by disguises

### DIFF
--- a/townsfolk/investigative/oracle
+++ b/townsfolk/investigative/oracle
@@ -2,6 +2,6 @@
 __Basics__
 Every night, the Oracle can select two players and see if they have the same alignment as each other. 
 __Details__
-Each night, the Oracle can inspect two players. The Oracle will be told whether their roles have the same alignment or not. This result is affected by disguises. 
+Each night, the Oracle can inspect two players. The Oracle will be told whether their roles have the same alignment or not. This result is not affected by disguises. 
 The Oracle can select itself as one of the two players, but can only select each player once throughout the game. 
 Inspecting players is an immediate ability. Unaligned roles have the same alignment, solo roles do not.


### PR DESCRIPTION
Fixes #6 
This is technically a minor bugfix, but I'm making it a PR because the role description previously was mistakenly the opposite