### PR TITLE
Solo category change (<Team> <Category> => Solo <Category> {- <Team> Team})

### DIFF
--- a/limited/archangel
+++ b/limited/archangel
@@ -1,4 +1,4 @@
-**Archangel** | Heaven Killing
+**Archangel** | Solo Killing - Heaven Team
 __Basics__
 The Archangel is an alternative version of the devil.
 __Details__

--- a/limited/evil scientist
+++ b/limited/evil scientist
@@ -1,4 +1,4 @@
-**Evil Scientist** | Disease Killing
+**Evil Scientist** | Solo Killing - Disease Team
 __Basics__
 The Evil Scientist has invented a new disease, lethal and highly contagious. Their desire is to
 kill off all players.

--- a/limited/flute apprentice
+++ b/limited/flute apprentice
@@ -1,4 +1,4 @@
-**Flute Apprentice** | Flute Power
+**Flute Apprentice** | Solo Power - Flute Team
 __Basics__
 The Flute Apprentice is a Flute Player that can’t enchant other players; instead, they can join the enchanted channel.
 __Details__

--- a/limited/flute apprentice
+++ b/limited/flute apprentice
@@ -1,4 +1,4 @@
-**Flute Apprentice** | Solo/Flute Power
+**Flute Apprentice** | Flute Power
 __Basics__
 The Flute Apprentice is a Flute Player that can’t enchant other players; instead, they can join the enchanted channel.
 __Details__

--- a/limited/ice queen
+++ b/limited/ice queen
@@ -1,4 +1,4 @@
-**Ice Queen** | Ice Royals Power
+**Ice Queen** | Solo Power - Ice Royals Team
 __Basics__
 Each night, the Ice Queen can submit the role of one player, and if that guess is correct, the Ice Queen is able to use the guessed player’s ability on the next day.
 __Details__

--- a/limited/plaguebearer
+++ b/limited/plaguebearer
@@ -1,4 +1,4 @@
-**Plaguebearer** | Graveyard Power
+**Plaguebearer** | Solo Power - Graveyard Team
 __Basics__
 The Plaguebearer is an alternative version of the vampire.
 __Details__

--- a/limited/reaper
+++ b/limited/reaper
@@ -1,4 +1,4 @@
-**Reaper** | Nightmare Power
+**Reaper** | Solo Power - Nightmare Team
 __Basics__
 The Reaper can give living players powers of dead players, temporarily. This turns them Sleepless. The Reaper wins when all living players have been turned Sleepless.
 __Details__

--- a/limited/reaper
+++ b/limited/reaper
@@ -1,4 +1,4 @@
-**Reaper** | Solo Power
+**Reaper** | Nightmare Power
 __Basics__
 The Reaper can give living players powers of dead players, temporarily. This turns them Sleepless. The Reaper wins when all living players have been turned Sleepless.
 __Details__

--- a/limited/saint
+++ b/limited/saint
@@ -1,4 +1,4 @@
-**Saint** | Heaven Miscellaneous
+**Saint** | Solo Miscellaneous - Heaven Team
 __Basics__
 The Saint is an alternative version of the demon.
 __Details__

--- a/limited/wisp
+++ b/limited/wisp
@@ -1,4 +1,4 @@
-**Wisp** | Pyro Killing
+**Wisp** | Solo Killing - Pyro Team
 __Basics__
 The Wisp visits a person each night, igniting them if they are powdered. 
 __Details__

--- a/limited/zombie
+++ b/limited/zombie
@@ -1,4 +1,4 @@
-**Zombie** | Graveyard Miscellaneous
+**Zombie** | Solo Miscellaneous - Graveyard Team
 __Basics__
 The Zombie is an alternative version of the undead.
 __Details__

--- a/other/flute/flute player
+++ b/other/flute/flute player
@@ -1,4 +1,4 @@
-**Flute Player** | Flute Power
+**Flute Player** | Solo Power - Flute Team
 __Basics__
 Each night, the Flute Player may enchant two players. 
 If all living players are either enchanted or Flute Player(s), the Flute Player(s) win.

--- a/other/hell/demon
+++ b/other/hell/demon
@@ -1,4 +1,4 @@
-**Demon** | Hell Miscellaneous
+**Demon** | Solo Miscellaneous - Hell Team
 __Basics__
 The Demon wins with the devil and joins a channel with the devil to communicate securely.
 __Details__

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -1,4 +1,4 @@
-**Devil** | Solo/Hell Killing
+**Devil** | Hell Killing
 __Basics__
 Each day, the Devil may choose a player to send the devil’s wager to. 
 The target may choose to either learn another player’s role, or attack another player, but sell their soul in the process. 

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -1,4 +1,4 @@
-**Devil** | Hell Killing
+**Devil** | Solo Killing - Hell Team
 __Basics__
 Each day, the Devil may choose a player to send the devil’s wager to. 
 The target may choose to either learn another player’s role, or attack another player, but sell their soul in the process. 

--- a/other/ice royals/ice king
+++ b/other/ice royals/ice king
@@ -1,4 +1,4 @@
-**Ice King** | Ice Royals Power
+**Ice King** | Solo Power - Ice Royals Team
 __Basics__
 Each night, the Ice King can submit a list of players. Every player the Ice King guesses correctly will have their public votes nulled.
 __Details__

--- a/other/pyro/pyromancer
+++ b/other/pyro/pyromancer
@@ -1,4 +1,4 @@
-**Pyromancer** | Pyro Killing
+**Pyromancer** | Solo Killing - Pyro Team
 __Basics__
 Each night, the Pyromancer may either powder a player or ignite all currently powdered players.
 __Details__

--- a/other/underworld/undead
+++ b/other/underworld/undead
@@ -1,4 +1,4 @@
-**Undead** | Underworld Miscellaneous
+**Undead** | Solo Miscellaneous - Underworld Team
 __Basics__
 The Undead are the vampire’s secret army. If a demonized player is attacked during the night, they will lose their original role and become an Undead.
 __Details__

--- a/other/underworld/vampire
+++ b/other/underworld/vampire
@@ -1,4 +1,4 @@
-**Vampire** | Underworld Power
+**Vampire** | Solo Power - Underworld Team
 __Basics__
 The Vampire wins by secretly turning all the living players into undead. 
 The Vampire demonizes players; if a demonized player is killed in the night, they will instead turn into an undead.


### PR DESCRIPTION
Some other roles still had their team listed as "solo" when they actually have their own team names.