### PR TITLE
Child/RK Edge Case moved to RK

### DIFF
--- a/townsfolk/miscellaneous/child
+++ b/townsfolk/miscellaneous/child
@@ -4,4 +4,3 @@ The day after the Child dies, there will be two lynches instead of one.
 __Details__ 
 Whenever the Child dies, there is an additional lynch the next day. If more than one Child dies, there can be more than two lynches.
 It is allowed to lynch the same player several times. This is useful in scenarios where the werewolves want to lynch an Executioner, who can avoid one lynch. 
-Each royal knight can only cancel one lynch.

--- a/townsfolk/power/royal knight
+++ b/townsfolk/power/royal knight
@@ -2,6 +2,6 @@
 __Basics__
 Once per game, the Royal Knight may cancel the lynch.
 __Details__
-The Royal Knight may cancel the lynch at any time of day or night, and it will apply to the next lynch.
+The Royal Knight may cancel the lynch at any time of day or night, and it will apply to the next lynch. If there are several lynches the Royal Knight may only cancel one of them.
 Cancelling the lynch is an immediate ability. However, the fact that the lynch has been canceled will only be revealed at the end of the day. 
 The Royal Knight also receives the choice whether they want to be revealed or not. Cancelling the lynch results in nobody dying from the lynch that day. 


### PR DESCRIPTION
Moved the Child/Royal Knight edge case from the Child description to the Royal Knight description. It was originally in the Child description as the Child was a limited role and hence the edge case couldn't be in the RK description.