### PR TITLE
Major Devil Revamp

### DIFF
--- a/channels/wager
+++ b/channels/wager
@@ -2,8 +2,10 @@
 
 You can decide to either:
 
-1. Kill someone, and sell your soul in the process
+1. Kill someone, but sell your soul in the process
 
-2. Check someone's role, but the Devil will also see the result.
+2. Protect someone, but sell your soul in the process
 
-3. Ignore, and don't do anything.
+3. Check someone's role, but the Devil will see the result and also your role
+
+4. Ignore, and don't do anything.

--- a/channels/wager
+++ b/channels/wager
@@ -2,9 +2,9 @@
 
 You can decide to either:
 
-1. Kill someone, but sell your soul in the process
+1. Attack a player, but sell your soul in the process
 
-2. Protect someone, but sell your soul in the process
+2. Protect yourself or any player, but sell your soul in the process
 
 3. Check someone's role, but the Devil will see the result and also your role
 

--- a/other/hell/demon
+++ b/other/hell/demon
@@ -7,7 +7,7 @@ At the start of the game, the Demon may choose a role as a weak disguise. If the
 
 The Demon is soulless and their soul is in the hell team's pool of souls.
 The Demon may use souls from the pool to protect or attack somebody. 
-If the Demon is attacked while a soul is in the pool the soul will automatically be used to protect the Demon. 
+If the Demon is attacked while a soul is in the pool, a soul will automatically be used to protect the Demon. 
 Use `$info souls` for a detailed explanation.
 
 Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/demon
+++ b/other/hell/demon
@@ -5,7 +5,7 @@ Just like the devil the Demon can use the hell team's pool of souls.
 __Details__
 At the start of the game, the Demon may choose a role as a weak disguise. If the Demon doesn’t choose a role, they will show up as a citizen.
 
-The Demon is soulless and their soul is in the hell team's pool of souls.
+At the start of the game the Demon's soul is added to the hell team's pool of souls, and they are soulless afterwards.
 The Demon may use souls from the pool to protect or attack somebody. 
 If the Demon is attacked while a soul is in the pool, a soul will automatically be used to protect the Demon. 
 Use `$info souls` for a detailed explanation.

--- a/other/hell/demon
+++ b/other/hell/demon
@@ -1,0 +1,13 @@
+**Demon** | Solo Killing - Hell Team
+__Basics__
+The Demon wins with the devil and joins a channel with the devil to communicate securely.
+Just like the devil the Demon can use the hell team's pool of souls.
+__Details__
+At the start of the game, the Demon may choose a role as a weak disguise. If the Demon doesn’t choose a role, they will show up as a citizen.
+
+The Demon is soulless and their soul is in the hell team's pool of souls.
+The Demon may use souls from the pool to protect or attack somebody. 
+If the Demon is attacked while a soul is in the pool the soul will automatically be used to protect the Demon. 
+Use `$info souls` for a detailed explanation.
+
+Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/demon
+++ b/other/hell/demon
@@ -1,8 +1,0 @@
-**Demon** | Solo Miscellaneous - Hell Team
-__Basics__
-The Demon wins with the devil and joins a channel with the devil to communicate securely.
-__Details__
-The Demon is usually the result of someone copying the devil for various reasons. This is because the devil is too powerful for there to be two. 
-Their win condition is the same as the Devil’s. The Demon starts out soulless.
-
-Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -9,11 +9,13 @@ At the start of the game, the Devil may choose a role as a weak disguise. If the
 
 The Devil is soulless and their soul is in the hell team's pool of souls.
 The Devil may use souls from the pool to protect or attack somebody. 
-If the Devil is attacked while a soul is in the pool the soul will automatically be used to protect the Devil. (`$info souls` for a detailed explanation)
+If the Devil is attacked while a soul is in the pool the soul will automatically be used to protect the Devil. 
+Use `$info souls` for a detailed explanation.
 
 The Devil can't send the wager to soulless players. The wager is sent at the end of the day. 
 The Devil can anonymously communicate with the target.
 The recipient may choose to sell their soul to protect or attack somebody, or to share their identity to learn the role of another player. 
-They may also ignore the wager. (`$info wager` for a detailed explanation)
+Alternatively, they may also ignore the wager.
+Use `$info wager` for a detailed explanation.
 
 Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -9,7 +9,7 @@ At the start of the game, the Devil may choose a role as a weak disguise. If the
 
 The Devil is soulless and their soul is in the hell team's pool of souls.
 The Devil may use souls from the pool to protect or attack somebody. 
-If the Devil is attacked while a soul is in the pool the soul will automatically be used to protect the Devil. 
+If the Devil is attacked while a soul is in the pool, a soul will automatically be used to protect the Devil. 
 Use `$info souls` for a detailed explanation.
 
 The Devil can't send the wager to soulless players. The wager is sent at the end of the day. 

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -7,7 +7,7 @@ When everyone is dead or soulless the Devil wins.
 __Details__
 At the start of the game, the Devil may choose a role as a weak disguise. If the Devil doesn’t choose a role, they will show up as a citizen.
 
-The Devil is soulless and their soul is in the hell team's pool of souls.
+At the start of the game the Devil's soul is added to the hell team's pool of souls, and they are soulless afterwards.
 The Devil may use souls from the pool to protect or attack somebody. 
 If the Devil is attacked while a soul is in the pool, a soul will automatically be used to protect the Devil. 
 Use `$info souls` for a detailed explanation.

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -1,22 +1,49 @@
 **Devil** | Solo Killing - Hell Team
 __Basics__
 Each day, the Devil may choose a player to send the devil’s wager to. 
-The target may choose to either learn another player’s role, or attack another player, but sell their soul in the process. 
-The Devil has a variety of uses for souls. 
+The devil's wager recipient may choose one of four options.
+The Devil can use the hell team's pool of souls.
 When everyone is dead or soulless the Devil wins.
 __Details__
-The Devil can't target soulless players. The wager is sent at the end of the day. 
-The Devil can anonymously communicate with the target & will be notified of the result of the wager - they will learn who was attacked/which person was inspected & what role the target saw. 
-
-If the player chooses to see another player’s role (immediate), it will be affected by weak disguises and obstructions. These effects are seen from the player’s perspective, not the Devil’s.
-If the player chooses to attack another player (soul sold: immediately; kill executed: end-night), then they will become soulless. The attacker is the Devil. 
-If the player chooses to attack the Devil the attack will not be executed, but they will not be informed of this. However, they still sell their soul to the Devil.
-
-The Devil can use a soul to protect someone else from all attacks for the next night (day; immediate) or kill a player of their liking (day/night; immediate). 
-If the Devil is attacked at night and they have spare souls, they will be protected and a soul will be used up automatically. 
-
-The Devil starts the game off with a single soul that they can use whenever.
 At the start of the game, the Devil may choose a role as a weak disguise. If the Devil doesn’t choose a role, they will show up as a citizen.
 
-The Devil starts out soulless.
+The Devil is soulless and their soul is in the hell team's pool of souls.
+The Devil may use souls from the pool to protect or attack somebody. 
+If the Devil is attacked while a soul is in the pool the soul will automatically be used to protect the Devil. (`$info souls` for a detailed explanation)
+
+The Devil can't send the wager to soulless players. The wager is sent at the end of the day. 
+The Devil can anonymously communicate with the target.
+The recipient may choose to sell their soul to protect or attack somebody, or to share their identity to learn the role of another player. 
+They may also ignore the wager. (`$info wager` for a detailed explanation)
+
 Members of the Hell team cannot change role or betray the team in any way.
+
+
+
+**Devil's Wager** | Additional Info - Hell Team
+The Devil's Wager recipient may choose one of these four options:
+1) The recipient may choose to sell their identity, to see another player’s role.
+Checking another player is an immediate effect. Afterwards, the devil is privately informed what role the recipient has.
+Both of the investigations are affected by weak disguises and obstructions. These effects are seen from the devil’s perspective, not the recipients’s.
+
+2) The recipient may choose to sell their soul, to attack another player. 
+Selling the soul immediately adds it to the pool. At the end of the night the devil will attack the player chosen by the recipient.
+If the recipient chooses a member of the hell team, they will sell their soul as normal, but the devil will not execute the attack. The recipient is not informed.
+
+3) The recipient may choose to sell their soul, to protect a player.
+Selling the soul immediately adds it to the pool. For the rest of the night the player chosen by the recipient will be protected from any attacks to target them.
+The recipient may choose to protect themself.
+
+4) The recipient may choose to ignore the devil's wager. 
+
+**Souls** | Additional Info - Hell Team
+Members of the hell team that can use Souls may use a Soul to protect someone else from all attacks for the current night. If used during the day the player will be protected for the next night.
+Using a Soul to protect a player is an immediate effect.
+
+Members of the hell team that can use Souls may use a Soul to kill a player. The player will be killed immediately and it is not revealed why they died. 
+This ability may be used during both day and night.
+
+If a member of the hell that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
+If they are attacked several times a soul is used for every attack. 
+If several members of the hell team are attacked at the same time and there aren't enough souls to protect them all, the protections are choosen randomly, but the Devil is always protected first.
+

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -13,7 +13,7 @@ If the Devil is attacked while a soul is in the pool, a soul will automatically 
 Use `$info souls` for a detailed explanation.
 
 The Devil can't send the wager to soulless players. The wager is sent at the end of the day. 
-The Devil can anonymously communicate with the target.
+The Devil can anonymously communicate with the recipient.
 The recipient may choose to sell their soul to protect or attack somebody, or to share their identity to learn the role of another player. 
 Alternatively, they may also ignore the wager.
 Use `$info wager` for a detailed explanation.

--- a/other/hell/devil
+++ b/other/hell/devil
@@ -17,33 +17,3 @@ The recipient may choose to sell their soul to protect or attack somebody, or to
 They may also ignore the wager. (`$info wager` for a detailed explanation)
 
 Members of the Hell team cannot change role or betray the team in any way.
-
-
-
-**Devil's Wager** | Additional Info - Hell Team
-The Devil's Wager recipient may choose one of these four options:
-1) The recipient may choose to sell their identity, to see another player’s role.
-Checking another player is an immediate effect. Afterwards, the devil is privately informed what role the recipient has.
-Both of the investigations are affected by weak disguises and obstructions. These effects are seen from the devil’s perspective, not the recipients’s.
-
-2) The recipient may choose to sell their soul, to attack another player. 
-Selling the soul immediately adds it to the pool. At the end of the night the devil will attack the player chosen by the recipient.
-If the recipient chooses a member of the hell team, they will sell their soul as normal, but the devil will not execute the attack. The recipient is not informed.
-
-3) The recipient may choose to sell their soul, to protect a player.
-Selling the soul immediately adds it to the pool. For the rest of the night the player chosen by the recipient will be protected from any attacks to target them.
-The recipient may choose to protect themself.
-
-4) The recipient may choose to ignore the devil's wager. 
-
-**Souls** | Additional Info - Hell Team
-Members of the hell team that can use Souls may use a Soul to protect someone else from all attacks for the current night. If used during the day the player will be protected for the next night.
-Using a Soul to protect a player is an immediate effect.
-
-Members of the hell team that can use Souls may use a Soul to kill a player. The player will be killed immediately and it is not revealed why they died. 
-This ability may be used during both day and night.
-
-If a member of the hell that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
-If they are attacked several times a soul is used for every attack. 
-If several members of the hell team are attacked at the same time and there aren't enough souls to protect them all, the protections are choosen randomly, but the Devil is always protected first.
-

--- a/other/hell/imp
+++ b/other/hell/imp
@@ -3,6 +3,6 @@ __Basics__
 The Imp wins with the devil and joins a channel with the devil to communicate securely.
 __Details__
 The Imp is usually the result of someone copying the devil for various reasons. This is because the devil is too powerful for there to be two. 
-Their win condition is the same as the Devil’s. The Imp starts out soulless.
+Their win condition is the same as the Devil’s. When an Imp is created they lose their soul and it becomes part of the hell team's pool of souls.
 
 Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/imp
+++ b/other/hell/imp
@@ -1,0 +1,8 @@
+**Imp** | Solo Miscellaneous - Hell Team
+__Basics__
+The Imp wins with the devil and joins a channel with the devil to communicate securely.
+__Details__
+The Imp is usually the result of someone copying the devil for various reasons. This is because the devil is too powerful for there to be two. 
+Their win condition is the same as the Devil’s. The Demon starts out soulless.
+
+Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/imp
+++ b/other/hell/imp
@@ -3,6 +3,6 @@ __Basics__
 The Imp wins with the devil and joins a channel with the devil to communicate securely.
 __Details__
 The Imp is usually the result of someone copying the devil for various reasons. This is because the devil is too powerful for there to be two. 
-Their win condition is the same as the Devil’s. The Demon starts out soulless.
+Their win condition is the same as the Devil’s. The Imp starts out soulless.
 
 Members of the Hell team cannot change role or betray the team in any way.

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -1,5 +1,5 @@
 **Souls** | Additional Info - Hell Team
-Members of the hell team that can use Souls may use a Soul to protect someone else from all attacks for the current night. If used during the day the player will be protected for the next night.
+Members of the hell team that can use Souls may use a Soul to protect someone from all attacks for the current night. If used during the day the player will be protected for the next night.
 Using a Soul to protect a player is an immediate effect.
 
 Members of the hell team that can use Souls may use a Soul to kill a player. The player will be killed immediately and it is not revealed why they died. 

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -5,6 +5,6 @@ Using a Soul to protect a player is an immediate effect.
 Members of the hell team that can use Souls may use a Soul to kill a player. The player will be killed immediately and it is not revealed why they died. 
 This ability may be used during both day and night.
 
-If a member of the hell that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
+If a member of the hell team that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
 If they are attacked several times a soul is used for every attack. 
 If several members of the hell team are attacked at the same time and there aren't enough souls to protect them all, the protections are choosen randomly, but the Devil is always protected first.

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -1,0 +1,10 @@
+**Souls** | Additional Info - Hell Team
+Members of the hell team that can use Souls may use a Soul to protect someone else from all attacks for the current night. If used during the day the player will be protected for the next night.
+Using a Soul to protect a player is an immediate effect.
+
+Members of the hell team that can use Souls may use a Soul to kill a player. The player will be killed immediately and it is not revealed why they died. 
+This ability may be used during both day and night.
+
+If a member of the hell that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
+If they are attacked several times a soul is used for every attack. 
+If several members of the hell team are attacked at the same time and there aren't enough souls to protect them all, the protections are choosen randomly, but the Devil is always protected first.

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -7,4 +7,4 @@ This ability may be used during both day and night.
 
 If a member of the hell team that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
 If they are attacked several times a soul is used for every attack. 
-If several members of the hell team are attacked at the same time and there aren't enough souls to protect them all, the protections are choosen randomly, but the Devil is always protected first.
+If several members of the hell team are attacked at the same time and there aren't enough souls to protect them all, the protections are chosen randomly, but the Devil is always protected first.

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -2,7 +2,7 @@
 Members of the hell team that can use Souls may use a Soul to protect someone from all attacks for the current night. If used during the day the player will be protected for the next night.
 Using a Soul to protect a player is an immediate effect.
 
-Members of the hell team that can use Souls may use a Soul to attack a player. The player will be attack immediately and it is not revealed why they died. 
+Members of the hell team that can use Souls may use a Soul to attack a player. The player will be attacked immediately and it is not revealed why they died. 
 This ability may be used during both day and night. If the attack fails it is explained.
 
 If a member of the hell team that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 

--- a/other/hell/souls
+++ b/other/hell/souls
@@ -2,8 +2,8 @@
 Members of the hell team that can use Souls may use a Soul to protect someone from all attacks for the current night. If used during the day the player will be protected for the next night.
 Using a Soul to protect a player is an immediate effect.
 
-Members of the hell team that can use Souls may use a Soul to kill a player. The player will be killed immediately and it is not revealed why they died. 
-This ability may be used during both day and night.
+Members of the hell team that can use Souls may use a Soul to attack a player. The player will be attack immediately and it is not revealed why they died. 
+This ability may be used during both day and night. If the attack fails it is explained.
 
 If a member of the hell team that that can use Souls is attacked during the night and if they have a spare soul in the pool, they will be protected and a soul will be used up automatically. 
 If they are attacked several times a soul is used for every attack. 

--- a/other/hell/wager
+++ b/other/hell/wager
@@ -1,15 +1,15 @@
 **Devil's Wager** | Additional Info - Hell Team
 The Devil's Wager recipient may choose one of these four options:
-1) The recipient may choose to sell their identity, to see another player’s role.
-Checking another player is an immediate effect. Afterwards, the devil is privately informed what role the recipient has.
-Both of the investigations are affected by weak disguises and obstructions. These effects are seen from the devil’s perspective, not the recipients’s.
-
-2) The recipient may choose to sell their soul, to attack another player. 
+1) The recipient may choose to sell their soul, to attack another player. 
 Selling the soul immediately adds it to the pool. At the end of the night the devil will attack the player chosen by the recipient.
 If the recipient chooses a member of the hell team, they will sell their soul as normal, but the devil will not execute the attack. The recipient is not informed.
 
-3) The recipient may choose to sell their soul, to protect a player.
+2) The recipient may choose to sell their soul, to protect a player.
 Selling the soul immediately adds it to the pool. For the rest of the night the player chosen by the recipient will be protected from any attacks to target them.
 The recipient may choose to protect themself.
+
+3) The recipient may choose to sell their identity, to see another player’s role.
+Checking another player is an immediate effect. Afterwards, the devil is privately informed what role the recipient has.
+Both of the investigations are affected by weak disguises and obstructions. These effects are seen from the devil’s perspective, not the recipients’s.
 
 4) The recipient may choose to ignore the devil's wager. 

--- a/other/hell/wager
+++ b/other/hell/wager
@@ -1,0 +1,15 @@
+**Devil's Wager** | Additional Info - Hell Team
+The Devil's Wager recipient may choose one of these four options:
+1) The recipient may choose to sell their identity, to see another player’s role.
+Checking another player is an immediate effect. Afterwards, the devil is privately informed what role the recipient has.
+Both of the investigations are affected by weak disguises and obstructions. These effects are seen from the devil’s perspective, not the recipients’s.
+
+2) The recipient may choose to sell their soul, to attack another player. 
+Selling the soul immediately adds it to the pool. At the end of the night the devil will attack the player chosen by the recipient.
+If the recipient chooses a member of the hell team, they will sell their soul as normal, but the devil will not execute the attack. The recipient is not informed.
+
+3) The recipient may choose to sell their soul, to protect a player.
+Selling the soul immediately adds it to the pool. For the rest of the night the player chosen by the recipient will be protected from any attacks to target them.
+The recipient may choose to protect themself.
+
+4) The recipient may choose to ignore the devil's wager. 


### PR DESCRIPTION
- changed the invest option (now you need to sell your identity) (wager)
- clarified that ignoring is an option (wager)
- added a protection option (wager)
- the devil now refuses to kill anyone from hell team and not just the devil
- clarify that auto soul defense uses 1 soul per attack
- split wager and soul info into different sections
- demon renamed to imp (only meant for copying)
- demon readded as a role that's like devil but without the wager (which is meant to be added to role lists)
- the souls are now in a pool of souls and not on the devil
- added separate more detailed info for wager & souls
- each Devil and Demon adds 1 soul to the initial pool of souls
- when an imp is created hell team gains a soul