### PR TITLE
Create socialite

### DIFF
--- a/categories/Townsfolk Group
+++ b/categories/Townsfolk Group
@@ -4,4 +4,4 @@ Butcher
 Cult Member
 
 *Juror*
- 
+*Socialite*

--- a/limited/socialite
+++ b/limited/socialite
@@ -1,4 +1,4 @@
-**Socialite** | Townsfolk Group
+**Socialite** | Townsfolk Group | Limited
 __Basics__
 The Socialite is included in all townsfolk secret channels, and counts as every role for some abilities.
 __Details__

--- a/limited/socialite
+++ b/limited/socialite
@@ -1,0 +1,8 @@
+**Socialite** | Townsfolk Group
+__Basics__
+The Socialite is included in all townsfolk secret channels, and counts as every role for some abilities.
+__Details__
+The Socialite will always join baker, butcher, and cult chat channels. They will receive a cult vote.
+The Socialite add 1 to all receptionist results, and always give a positive result to Psychic Wolf and Crown Seeker guesses.
+Journalist journals will be received by the Socialite if no other player is the named role.
+Role checking, threat checking, and "part of the wolfpack" checks function as normal.


### PR DESCRIPTION
Socialite was inspired by a conversation on the discord.

It's a group role that joins all the available townsfolk groups. It can also be used in games without groups with it's secondary ability to act as any role for role guessing and journalist games.