### PR TITLE
Create Firebug

### DIFF
--- a/categories/Solo Power
+++ b/categories/Solo Power
@@ -7,3 +7,4 @@ Vampire (Underworld Team)
 *Ice Queen (Ice Royals Team)*
 *Reaper (Nightmare Team)*
 *Shepherd (Flock Team)*
+*Firebug (Pyro Team)*

--- a/categories/Solo Team Pyro
+++ b/categories/Solo Team Pyro
@@ -2,3 +2,4 @@
 Pyromancer
 
 *Wisp*
+*Firebug*

--- a/limited/Firebug
+++ b/limited/Firebug
@@ -1,4 +1,4 @@
-**Firebug** | Pyro Power | Limited
+**Firebug** | Solo Power - Pyro Team | Limited
 __Basics__
 Each day the Firebug can choose to powder a player, this will be communicated to the main pyromancers at the start of the night and can be cancelled at any point in the night, who will then be powdered at the end of the next night. 
 __Details__

--- a/limited/Firebug
+++ b/limited/Firebug
@@ -1,0 +1,8 @@
+**Firebug** | Pyro Power
+__Basics__
+Each day the Firebug can choose to powder a player, this will be communicated to the main pyromancers at the start of the night and can be cancelled at any point in the night, who will then be powdered at the end of the next night. 
+__Details__
+During the day the Firebug may choose one player to powder or unpowder, this can be changed at any point before the end of the day, the player the Firebug chose to powder will be communicated in the pyro channel.
+At any point in the night the Firebug can choose to cancel their powder, the pyros will be told if the Firebug cancels it, if the Firebug doesn’t cancel their powder in the night the player will be powdered.
+The Firebug is told if they are powdered and can unpowder themselves if they are powdered.
+The Firebug is not a member of the pyro team and channel. If all the main team pyros die the Firebug will be promoted to a pyromancer.

--- a/limited/Firebug
+++ b/limited/Firebug
@@ -3,6 +3,6 @@ __Basics__
 Each day the Firebug can choose to powder a player, this will be communicated to the main pyromancers at the start of the night and can be cancelled at any point in the night, who will then be powdered at the end of the next night. 
 __Details__
 During the day the Firebug may choose one player to powder or unpowder, this can be changed at any point before the end of the day, the player the Firebug chose to powder will be communicated in the pyro channel.
-At any point in the night the Firebug can choose to cancel their powder, the pyros will be told if the Firebug cancels it, if the Firebug doesn’t cancel their powder in the night the player will be powdered.
+At any point in the night the Firebug can choose to cancel or approve their powder, the pyros will be told if the Firebug cancels it, if the Firebug doesn’t cancel their powder and approves it then the target will be powdered immediately.
 The Firebug is told if they are powdered and can unpowder themselves if they are powdered.
 The Firebug is not a member of the pyro team and channel. If all the main team pyros die the Firebug will be promoted to a pyromancer.

--- a/limited/Firebug
+++ b/limited/Firebug
@@ -1,4 +1,4 @@
-**Firebug** | Pyro Power
+**Firebug** | Pyro Power | Limited
 __Basics__
 Each day the Firebug can choose to powder a player, this will be communicated to the main pyromancers at the start of the night and can be cancelled at any point in the night, who will then be powdered at the end of the next night. 
 __Details__


### PR DESCRIPTION
The Firebug is currently a, mini wolves only, weaker version of a Pyromancer

This version updates the role the Firebug to be a role to help balance Pyros for games where 1 extra pyro would be too much and without the pyro they would be too weak