### PR TITLE
Remove the weird win condition thing from GWW

### DIFF
--- a/other/solo/gray werewolf
+++ b/other/solo/gray werewolf
@@ -6,5 +6,6 @@ __Details__
 The Gray Werewolf is similar to the White Werewolf. A difference is that the Gray Werewolf can also win while one other player is alive. 
 The Gray Werewolf wins when the only remaining players are the Gray Werewolf and optionally another player. 
 Unlike the White Werewolf, the Gray Werewolf does not have a disguise. 
-Attacking a member of the wolfpack is an end effect. If only several werewolves and the Gray Werewolf are left alive, the game ends in a Werewolf victory.
-The Gray Werewolf is considered a lycan.
+Attacking a member of the wolfpack is an end effect.
+If only werewolves and the Gray Werewolf are left alive, the game will continue until either all werewolves are dead or the Gray Werewolf is dead.
+The Gray Werewolf is not part of the werewolf team, but is still considered a lycan and is part of the wolfpack.


### PR DESCRIPTION
GWW losing against werewolves is a fairly weird mechanic and I think it's an unnecessary debuff - GWW is already lacking the disguise/imitation that WWW has