### PR TITLE
change targeting rule

### DIFF
--- a/_rules/abilities/2 immediate abilities
+++ b/_rules/abilities/2 immediate abilities
@@ -1,4 +1,4 @@
 **Immediate Abilities**
 Most Immediate Abilities can only be used once per phase. Additionally, abilities like targetting usually have an emergency change once per game.
-Some targeting abilities (e.g. Executioner) can still be used even if the main power (e.g. lynching another player) has already be used.
+Targeting abilities (e.g. Executioner) are lost when the main power (e.g. lynching another player) has already be used.
  


### PR DESCRIPTION
For some reason the rules say roles like Executioner can still change their target even after using their power, which doesn't make any sense?