### PR TITLE
Rename "Uncertain Hag" to just "Hag"

### DIFF
--- a/categories/Unaligned Align
+++ b/categories/Unaligned Align
@@ -9,4 +9,4 @@ Look-Alike
 *Vicious Hag*
 *Cautious Hag*
 *Prophetic Hag*
-*Uncertain Hag*
+*Hag*

--- a/categories/Unaligned Align Hag
+++ b/categories/Unaligned Align Hag
@@ -2,6 +2,6 @@
 *Vicious Hag*
 *Cautious Hag*
 *Prophetic Hag*
-*Uncertain Hag*
+*Hag*
 
 *Bitter Hag*

--- a/unaligned/align - hag/uncertain hag
+++ b/unaligned/align - hag/uncertain hag
@@ -1,9 +1,9 @@
-**Uncertain Hag** | Unaligned Align | Limited
+**Hag** | Unaligned Align | Limited
 __Basics__
-The Uncertain Hag can win with any team, unless that team has wronged the hags. The Uncertain Hag will turn into another hag at the end of the day.
+The Hag can win with any team, unless that team has wronged the hags. The Hag will turn into a specific type of hag at the end of the day.
 __Details__
-The Uncertain Hag is one of the hags (`$i hags`).
-At the start of the game, the Uncertain Hag may name one type of hag. 
-At the end of the day the Uncertain Hag turns into one of the other hags, however they can not become the one they named nor can they immediately become a bitter hag.
-If the Uncertain Hag doesn't choose they can turn into any of the other hag roles (except bitter hag).
-The Uncertain Hag does not have a spell at the start of the game, but gains one later, as they turn into another hag.
+The Hag is one of the hags (`$i hags`).
+At the start of the game, the Hag may name one other hag role. 
+At the end of the day the Hag turns into one of the other hag roles, however they can not become the one they named nor can they immediately become a bitter hag.
+If the Hag doesn't choose they can turn into any of the other hag roles (except bitter hag).
+The Hag does not have a spell at the start of the game, but gains one later, as they turn into another hag role.


### PR DESCRIPTION
I think in any scenario where you use hags in the role list you should instead use this role (else the claim space is not as great), Uncertain Hag is a stupid name and was meant to be temporary. I think "Hag" sums the role up well enough. It's a Hag without a specialization (so far) and it doesn't sound kinda stupid like "Uncertain Hag"