### PR TITLE
An improvement of Plague Doctor

### DIFF
--- a/limited/plague bearer
+++ b/limited/plague bearer
@@ -11,3 +11,4 @@ Any player who visits or is visited by a contagious player is also immediately c
 At the start of the second night after being contaminated the player is informed that they are contaminated.
 At the end of the second night after being contaminated the player will die (cannot be avoided, not counted as an attack).
 If no members of the plague team remain all players are no longer contaminated, however they are not informed about this.
+If the Plague Bearer attempts to use a rodent on the Plague Doctor, the attempt fails, the Plague Doctor dies (unavoidable) and the rodent is *not* used up.

--- a/limited/plague doctor
+++ b/limited/plague doctor
@@ -4,5 +4,5 @@ The Plague Doctor is mostly immune to the plague bearer’s disease and requires
 __Details__
 As soon as the plague team is eliminated, the Plague Doctor ascends and wins.
 Each night, the Plague Doctor may check a player to see if they have the plague and, if they do, since when they have it. This is an immediate ability.
-If the plague bearer attempts to contaminate the Plague Doctor with one of their rodents, the Plague Doctor immediately dies.
+If the plague bearer attempts to contaminate the Plague Doctor with one of their rodents, the Plague Doctor dies (unavoidable).
 Otherwise, the Plague Doctor is immune to the disease.

--- a/limited/plague doctor
+++ b/limited/plague doctor
@@ -1,9 +1,9 @@
 **Plague Doctor** | Unaligned Miscellaneous | Limited
 __Basics__
-The Plague Doctor is mostly immune to the plague bearer’s disease and requires the plague team to be eliminated in order to win. They may check if players have the plague.
+The Plague Doctor is mostly immune to the plague bearer’s disease and requires the plague team to be eliminated in order to win. They may check a player for symptoms of the plague.
 __Details__
 As soon as the plague team is eliminated, the Plague Doctor ascends and wins.
-Each night, the Plague Doctor may check a player to see if they have the plague and, if they do, since when they have it. This is an immediate ability.
-Members of the plague team will *never* show up as having the plague.
+Each night, the Plague Doctor may check a player for symptoms of the plague. The Plague Doctor will immediately be informed if and since when their target has had the plague.
+Members of the plague team do not have any symptoms and will *never* show up as having the plague.
 If the plague bearer attempts to contaminate the Plague Doctor with one of their rodents, the Plague Doctor dies (unavoidable).
 Otherwise, the Plague Doctor is immune to the disease.

--- a/limited/plague doctor
+++ b/limited/plague doctor
@@ -1,9 +1,8 @@
 **Plague Doctor** | Unaligned Miscellaneous | Limited
 __Basics__
-The Plague Doctor is immune to the plague bearer’s disease and requires the plague team to be eliminated in order to win. They may check if players have the plague.
+The Plague Doctor is mostly immune to the plague bearer’s disease and requires the plague team to be eliminated in order to win. They may check if players have the plague.
 __Details__
 As soon as the plague team is eliminated, the Plague Doctor ascends and wins.
 Each night, the Plague Doctor may check a player to see if they have the plague and, if they do, since when they have it. This is an immediate ability.
-If the plague bearer attempts to contaminate the Plague Doctor, it fails and the rodent is used up.
-Both the plague bearer and the Plague Doctor are informed of the failure, however.
-The Plague Doctor must vote in every lynch poll. If they miss one, they will die immediately.
+If the plague bearer attempts to contaminate the Plague Doctor with one of their rodents, the Plague Doctor immediately dies.
+Otherwise, the Plague Doctor is immune to the disease.

--- a/limited/plague doctor
+++ b/limited/plague doctor
@@ -4,5 +4,6 @@ The Plague Doctor is mostly immune to the plague bearer’s disease and requires
 __Details__
 As soon as the plague team is eliminated, the Plague Doctor ascends and wins.
 Each night, the Plague Doctor may check a player to see if they have the plague and, if they do, since when they have it. This is an immediate ability.
+Members of the plague team will *never* show up as having the plague.
 If the plague bearer attempts to contaminate the Plague Doctor with one of their rodents, the Plague Doctor dies (unavoidable).
 Otherwise, the Plague Doctor is immune to the disease.


### PR DESCRIPTION
Fixes #449 

There is nothing the Plague team can do against the Plague Doctor, and since Plague team is the PD's only enemy nothing is stopping the PD to just say "I'm the PD" at the start of the game and be fine for the entire game. To be fair any other person could also claim to be the PD, but I'm not sure if that would actually happen. The PD can basically instantly public claim and it's probably somewhat difficult for anyone to cc the claim.

This change makes it so the plague team can actually do something against the Plague Doctor, meaning the Plague Doctor has to actually *play* instead of announcing their role and just surviving (this is in fact what happened when we previously had the old version of it in the game). The Plague team *cannot* be punished for targetting the Plague Doctor as then they'd have no reason to do so, and the PD could once again just announce their role. If the Plague team can kill the PD but needs to use up an rodent while doing so, the Plague team doesn't really profit from it. People targetted by rodents should *survive* as long as possible. So the idea is that they don't waste a rodent, merely a night (wasting a single night, but not a rodent is absolutely worth it).

I also propose to remove the voting thing. This is an leftover from when the Plague Doctor was the Immune Survivor (that being a variant of Survivor), and is no longer necessary with my proposed changes.

With my proposed changed the Plague Doctor can actually participate in the game in a meaningful, interesting and unique way. Already the previous changes to Plague Doctor give it a pseudo-investigative power, and with my proposed change this can be used to its fullest.
The Plague Doctor would think of the most likely targets for the plague, then check them. If they *have* the plague they can't be part of the plague team. This means the plague doctor could form some sort of alliance of players from different teams against the Plague team, which could potentially be an interesting mechanic. Furthermore, now that the PD won't immediately publicly claim on Day 0 this makes this role quit a bit more claimable.  

This still needs testing, but I can't imagine it could be less interesting than that one game with the old version of the role we played on vip.