### PR TITLE
Remove Gray Werewolf

### DIFF
--- a/archive/gray werewolf
+++ b/archive/gray werewolf
@@ -1,4 +1,4 @@
-**Gray Werewolf** | Solo Killing
+**Gray Werewolf** | Solo Killing | Archived
 __Basics__
 The Gray Werewolf is a werewolf who is not satisfied with merely killing the townsfolk; they must kill all the werewolves as well. 
 On even numbered nights, the Gray Werewolf may attack a member of the wolfpack.

--- a/categories/Solo Killing
+++ b/categories/Solo Killing
@@ -3,7 +3,6 @@ Demon (Hell Team)
 Devil (Hell Team)
 Pyromancer (Pyro Team)
 Wisp (Pyro Team)
-Gray Werewolf
 White Werewolf
 
 *Plague Bearer (Plague Team)*

--- a/categories/Solo Teams
+++ b/categories/Solo Teams
@@ -3,7 +3,6 @@ Hell
 Pyro
 Flute
 White Werewolf
-Gray Werewolf
 Cupid\*
 
 *Underworld*


### PR DESCRIPTION
This is a very unpopular role that is rarely used. I feel like this role encourages some sort of gamethrowing? (The other play wins with the GWW but their team loses?) That's just a strange and bad mechanic.