### PR TITLE
Remove Apprentice

### DIFF
--- a/archive/apprentice
+++ b/archive/apprentice
@@ -1,4 +1,4 @@
-**Apprentice** | Unaligned Align | Limited
+**Apprentice** | Unaligned Align | Archived
 __Basics__
 On first death or attack, the Apprentice will pick up the role of whoever is attacked.
 __Details__

--- a/categories/Unaligned Align
+++ b/categories/Unaligned Align
@@ -3,7 +3,6 @@ Cupid
 Dog
 Look-Alike
 
-*Apprentice*
 *Cat*
 *Thief*
 *Vicious Hag*


### PR DESCRIPTION
This role has *never* been used. I don't think we are very likely to use it, so there's no reason it should remain in the role book.