### PR TITLE
Clarifiction for how Hooker & Protection works

### DIFF
--- a/townsfolk/power/hooker
+++ b/townsfolk/power/hooker
@@ -5,3 +5,4 @@ __Details__
 Since the Hooker is at the other player’s house and not at home, any attacks targeting the Hooker in the night will fail; however, if the person they’re sleeping over at is being attacked, then they both are attacked.
 Choosing a player to sleep with is an immediate ability. From that point on, they will stay with that player for the rest of the night. The Hooker may also choose not to sleep with anybody.
 The Hooker may not sleep with the same player two nights in a row.
+If the Hooker is sleeping with another player while being protected from attacks, the protection is ignored; only protections for the player they are sleeping with apply.


### PR DESCRIPTION
hooker description specifies that "hooker will not be affected by attacks targetting them", wager protection specifies that "protected from any attacks to target them" => conclusion: if a hooker protects themselves while sleeping with someone they are not protected more than without the protection (since both hooker and protection specifically only protect from attacks targetting them)