### PR TITLE
Cub: Remove unnecessary sentence

### DIFF
--- a/werewolves/miscellaneous/wolfs cub
+++ b/werewolves/miscellaneous/wolfs cub
@@ -3,5 +3,4 @@ __Basics__
 The night after the Wolf’s Cub dies, the wolfpack will be able to kill an additional player.
 __Details__
 Whenever a Wolf's Cub dies, the other wolfpack members will be able to kill an additional player the night after the Wolf's Cub's death. They are allowed to attack the same player several times, if they like. 
-This is useful in scenarios where they want to kill runners or players who may have been demonized. 
 This ability is triggered when a player who at any point had the role of Wolf’s Cub dies, not when a Wolf’s Cub loses their role.


### PR DESCRIPTION
Remove an unnecessary sentence from the Wolf's Cub description as requested by Meuh
Fixes #528