### PR TITLE
Exorcist Day Ability

### DIFF
--- a/townsfolk/power/exorcist
+++ b/townsfolk/power/exorcist
@@ -1,8 +1,8 @@
 **Exorcist** | Townsfolk Power
 __Basics__
-Each night, the Exorcist may remove negative effects from one player.
+Each day, the Exorcist may remove negative effects from one player.
 __Details__
-Each night, the Exorcist can exorcise one player. All negative effects caused by solo roles are removed from the player and the Exorcist is informed which effects were removed. Exorcising a player is an immediate effect.
+Each day, the Exorcist can exorcise one player. All negative effects caused by solo roles are removed from the player and the Exorcist is informed which effects were removed. Exorcising a player is an immediate effect.
 Players that have already been exorcised can not be exorcised again. The Exorcist can not cure players if they have changed role as the result of an effect, such as the Undead, but can still remove other possible effects the Undead has. 
 The solo team whose effect is cured is informed about this.
 __Negative Effects__


### PR DESCRIPTION
The Exorcist's ability should be a day ability. This makes more sense because than Exorcist can better counter N1 effects and it avoids ability priority conflicts (Exorcist would always want to do their ability last). I think it's better to avoid as many of those ability order conflicts, because it's just weird for the players.