### PR TITLE
wisp change

### DIFF
--- a/other/pyro/wisp
+++ b/other/pyro/wisp
@@ -7,4 +7,5 @@ If that person is not powdered, the Wisp powders that person. This is an immedia
 The Wisp may not visit themself.
 The Wisp is a member of the pyro team, but not a member of the pyro channel. That means they do not know the other members of their team. 
 If the Wisp is ignited by the pyros the Wisp will be alerted they were ignited, but will not be killed. Whoever ignited the Wisp will be informed that their target could not be ignited. This message is unique and different from other ways the igniting could fail.
-When no members of the pyro channel are left, the Wisp is informed and turns into a pyromancer at the start of the next phase and join the pyro channel.
+When no members of the pyro channel are left, the Wisp is informed and turns into a pyromancer at the start of the next phase and joins the pyro channel.
+If several Wisps exist when the last member of the pyro channel dies, all of them turn into pyromancers and join the pyro channel.

--- a/other/pyro/wisp
+++ b/other/pyro/wisp
@@ -7,4 +7,4 @@ If that person is not powdered, the Wisp powders that person. This is an immedia
 The Wisp may not visit themself.
 The Wisp is a member of the pyro team, but not a member of the pyro channel. That means they do not know the other members of their team. 
 If the Wisp is ignited by the pyros the Wisp will be alerted they were ignited, but will not be killed. Whoever ignited the Wisp will be informed that their target could not be ignited. This message is unique and different from other ways the igniting could fail.
-When no members of the pyro channel are left, the Wisp is informed and immediately turns into a Pyromancer.
+When no members of the pyro channel are left, the Wisp is informed and turns into a pyromancer at the start of the next phase, but does not join the pyro channel.

--- a/other/pyro/wisp
+++ b/other/pyro/wisp
@@ -7,4 +7,4 @@ If that person is not powdered, the Wisp powders that person. This is an immedia
 The Wisp may not visit themself.
 The Wisp is a member of the pyro team, but not a member of the pyro channel. That means they do not know the other members of their team. 
 If the Wisp is ignited by the pyros the Wisp will be alerted they were ignited, but will not be killed. Whoever ignited the Wisp will be informed that their target could not be ignited. This message is unique and different from other ways the igniting could fail.
-When no members of the pyro channel are left, the Wisp is informed and turns into a pyromancer at the start of the next phase, but does not join the pyro channel.
+When no members of the pyro channel are left, the Wisp is informed and turns into a pyromancer at the start of the next phase and join the pyro channel.


### PR DESCRIPTION
Clarify that they do not join pyro channel
Add that they only promote at the start of the next phase - this means that if the last pyro is lynched the wisp action of that day still goes through
Fixes #552 