### PR TITLE
Improve Undead Phrasing

### DIFF
--- a/limited/zombie
+++ b/limited/zombie
@@ -3,11 +3,14 @@ __Basics__
 Each night, the Zombie may bite another player. If a player is bitten a second time they become a Zombie.
 __Details__
 When a Zombie bites another player they become "bitten". The bitten player does not know about this. When a Zombie bites a player that is already bitten, they immediately become a Zombie. 
-That player betrays their team and joins the graveyard channel. They can also immediately bite another player. If they previously were part of another group, they remain in it, but lose their vote. If all members of a certain group have been turned or are dead, their ability will be lost and the group is disbanded.
 If a Zombie dies, every other Zombie that has been turned by the dying Zombie also dies. 
 The Zombies win when all players are either dead or part of the graveyard team.
 Zombies are part of the graveyard channel and know the other Zombies and corpses.
 Zombies cannot bite other members of the graveyard channel.
+
+When a player turns into a Zombie, they betray their team and join the graveyard channel. They can also immediately bite another player. 
+They lose their previous role, but if they were part of a group like the wolfpack, they will remain in the channel and will still be able to vote (though internally their vote won't be counted) as long as at least one other member of their group is still alive. 
+Once all members have either been turned or are dead, the group is disbanded and any abilities it may have had are lost.
 __Edge Cases__
 If a Zombie changes their role, they will no longer die when its creator Zombie dies, nor will it cause the death of Zombies it has created (neither immediately, nor when it dies).
 If a Zombie tries to turn a member of the hell team (second bite), their power backfires, and instead the Zombie becomes an imp. Since members of hell can't be turned into Zombies, they may be bitten for a "second" time several times.

--- a/other/underworld/undead
+++ b/other/underworld/undead
@@ -1,8 +1,7 @@
 **Undead** | Solo Miscellaneous - Underworld Team
 __Basics__
-The Undead are the vampire’s secret army. If a demonized player were to die during the night, they will instead lose their original role and become an Undead.
+The Undead is a dead player who pretends to be alive, and they are part of the vampire’s secret army. If a demonized player dies during the night, they will not die, and will instead lose their original role and become an Undead.
 __Details__
-When a demonized player, that is not part of the underworld team or group, were to die during the night, they will not die and will instead become Undead and will be part of the vampire’s team. They have the same win condition as the vampire; they will win once all players are either vampire, dead or Undead.
-The Undead is one of the most complex roles in the game. 
-The Undead is a dead player who pretends to be alive. They lose their previous role, but if they were part of a group like the wolfpack, they will remain in the channel and be able to vote as long as at least one other member of their group is still alive. However in cases like the wolfpack, their vote will internally count for 0 when calculating the decision of the group poll. 
-If all members of a certain group have been turned or are dead, their ability will be lost and the group is disbanded.
+An Undead has the same win condition as the vampire; they will win when all remaining players are part of the underworld team.
+They lose their previous role, but if they were part of a group like the wolfpack, they will remain in the channel and will still be able to vote (though internally their vote won't be counted) as long as at least one other member of their group is still alive. 
+Once all members have either been turned or are dead, the group is disbanded and any abilities it may have had are lost.

--- a/other/underworld/undead
+++ b/other/underworld/undead
@@ -1,6 +1,6 @@
 **Undead** | Solo Miscellaneous - Underworld Team
 __Basics__
-The Undead is a dead player who pretends to be alive, and they are part of the vampire’s secret army. If a demonized player dies during the night, they will not die, and will instead lose their original role and become an Undead.
+The Undead is a part of the vampire’s secret army and pretends to be their old role. If a demonized player dies during the night, they will not die, and will instead lose their original role and become an Undead.
 __Details__
 An Undead has the same win condition as the vampire; they will win when all remaining players are part of the underworld team.
 They lose their previous role, but if they were part of a group like the wolfpack, they will remain in the channel and will still be able to vote (though internally their vote won't be counted) as long as at least one other member of their group is still alive. 


### PR DESCRIPTION
I think the role description for Undead is really bad right now. It has redundancy, a bit too much flavor and some things that aren't even really true. There's lots of leftovers from the style role descriptions had in the pre-WWR role book versions. It seems like more things just got added to the role description without really trying to keep the role description simple and readable
I've moved the flavor to the very start, where I think it makes the most sense. Additionally, I've gotten rid of some sections, combined some others and overall tried to make the role description better. There are no changes to how Undead works.