### PR TITLE
Scared Wolf: Remove mention of Runner

### DIFF
--- a/werewolves/miscellaneous/scared wolf
+++ b/werewolves/miscellaneous/scared wolf
@@ -2,4 +2,4 @@
 __Basics__
 The Scared Wolf will be protected from the first night attack to target them.
 __Details__
-The Scared Wolf is the runner of the werewolves. If it is attacked by anyone at night, it will escape unharmed the first time. The Scared Wolf is informed that they were attacked. After being attacked once, it will lose its ability.
+If it is attacked by anyone at night, it will escape unharmed the first time. The Scared Wolf is informed that they were attacked. After being attacked once, it will lose its ability.


### PR DESCRIPTION
The role description claims that ScW is like Runner. That's not really particularly true. The ScW can escape any attack (not just town attacks) and it's escape is a standard escape, not a special one like Runner (which tells the wolves it was a runner). We also got rid of phrases like this in most other places (like e.g. "The Warlock is the werewolf version of the Fortune Teller)