### PR TITLE
Some changes to cat

### DIFF
--- a/categories/Unaligned Align
+++ b/categories/Unaligned Align
@@ -1,11 +1,11 @@
 **Unaligned Align**
 Dog
+Cat
 Look-Alike
 Cupid
 Several Cupid Variants (`$i uac`)
 
 *Apprentice*
-*Cat*
 *Thief*
 *Hag*
 *Several Hag Variants (`$i uah`)*

--- a/limited/cat
+++ b/limited/cat
@@ -3,5 +3,5 @@ __Basics__
 During Night 1, the Cat will immediately become the opposite role dog choses for the rest of the game. 
 __Details__
 If the dog chooses town crier, the Cat will turn into wolf; cursed civilian will turn the Cat into a psychopath with the dog in the list; and wolf will turn the Cat into a town crier.
-Changing role is an immediate consequence of the dog choosing. If the dog hasn’t chosen a role before the night ends or there is no dog in the game, the Cat will become an angel. 
-The Cat can only be in games with exactly one dog.
+Changing role is an immediate consequence of the dog choosing.
+For each Cat in the game, there must be a corresponding dog. Neither the Cat, nor the dog will know their counterpart.

--- a/limited/cat
+++ b/limited/cat
@@ -2,6 +2,6 @@
 __Basics__
 During Night 1, the Cat will immediately become the opposite role dog choses for the rest of the game. 
 __Details__
-If the dog chooses town crier, the Cat will turn into wolf; cursed civilian will turn Cat into psychopath with the dog in the list; and wolf will turn the Cat into a town crier.
-Changing role is an immediate consequence of the dog choosing. If the dog hasn’t chosen a role before the night ends or there is no dog in the game, the Cat will be given the role of survivor. 
-The Cat can't be in the same game with more than one dog.
+If the dog chooses town crier, the Cat will turn into wolf; cursed civilian will turn the Cat into a psychopath with the dog in the list; and wolf will turn the Cat into a town crier.
+Changing role is an immediate consequence of the dog choosing. If the dog hasn’t chosen a role before the night ends or there is no dog in the game, the Cat will become an angel. 
+The Cat can only be in games with exactly one dog.

--- a/unaligned/align/cat
+++ b/unaligned/align/cat
@@ -5,3 +5,6 @@ __Details__
 If the dog chooses town crier, the Cat will turn into wolf; cursed civilian will turn the Cat into a psychopath with the dog in the list; and wolf will turn the Cat into a town crier.
 Changing role is an immediate consequence of the dog choosing.
 For each Cat in the game, there must be a corresponding dog. Neither the Cat, nor the dog will know their counterpart.
+
+__Simplified__
+For each Cat, there is a corresponding dog. The Cat will become the opposite of the role the dog chose.

--- a/unaligned/align/cat
+++ b/unaligned/align/cat
@@ -1,4 +1,4 @@
-**Cat** | Unaligned Align | Limited
+**Cat** | Unaligned Align
 __Basics__
 During Night 1, the Cat will immediately become the opposite role dog choses for the rest of the game. 
 __Details__

--- a/unaligned/align/dog
+++ b/unaligned/align/dog
@@ -2,4 +2,4 @@
 __Basics__
 During Night 1, the Dog may choose between town crier, cursed civilian or wolf, and will immediately become this role for the rest of the game.
 __Details__
-Choosing a role is an immediate ability. If the Dog hasn’t chosen a role before the night ends, the dog will be given the role of the citizen. After choosing a role the Dog is no longer unaligned.
+Choosing a role is an immediate ability. If the Dog hasn’t chosen a role before the night ends, the dog will become a cursed civilian. After choosing a role the Dog is no longer unaligned.


### PR DESCRIPTION
So I was reading the Reporter info, and I saw it mention Dog and then it occured to me that Dog has far more potential than I would've thought. Basically with a Dog you would be unable to know whether lynching a dog was a mislynch or not. However, of course with Dog the issue is balance. Cat's entire purpose is to address this issue, so I think games with both Cat and Dog would probably work out, since balance is still ensured.

Dog has four options:
Town Crier
Cursed Civilian
Wolf
Citizen

Town Crier and Wolf are considered to be opposite, so Cat just switches them. CC is considered to be inbetween those two (can benefit both alignments), so it makes sense that cat would become a Psycho, a role that in some way wants people from both alignments dead. That just leaves Citizen. The opposite of Citizen can't be Wolf because that's the opposite of TC, a role clearly stronger than Citizen, so I assume that's why the original Cat has Survivor. But Citizen is still definitely town-sided, so Survivor isn't a particularly good opposite _and_ more importantly Survivor doesn't exist. Packless Wolf would probably be the best equivalent, but it sucks and doesn't exist either. I think Angel would make for a better opposite - it exists and is generally a more wolf sided role, but not nearly as much as a wolf.

Also improved phrasing.