### PR TITLE
Correction regarding UAs

### DIFF
--- a/_categories/townsfolk
+++ b/_categories/townsfolk
@@ -1,2 +1,1 @@
 The Townsfolk Team wins when all players that aren’t part of the Townsfolk Team have been killed. An exception is Unaligned players, the townsfolk team does not need to kill them, however any Unaligned players that remain alive at the end of the game, but have not hit their win condition will still lose.
-

--- a/_categories/townsfolk
+++ b/_categories/townsfolk
@@ -1,1 +1,2 @@
-The Townsfolk Team wins when all players that aren’t part of the Townsfolk Team have been killed. Unaligned roles are an exception and can win with the Townsfolk Team.
+The Townsfolk Team wins when all players that aren’t part of the Townsfolk Team have been killed. An exception is Unaligned players, the townsfolk team does not need to kill them, however any Unaligned players that remain alive at the end of the game, but have not hit their win condition will still lose.
+

--- a/_categories/werewolves
+++ b/_categories/werewolves
@@ -1,1 +1,1 @@
-The Werewolf Team wins when all players that aren’t part of the Werewolf Team have been killed. Unaligned roles are an exception and can win with the Werewolf Team.
+The Werewolf Team wins when all players that aren’t part of the Werewolf Team have been killed. An exception is Unaligned players, the werewolves do not need to kill them, however any Unaligned players that remain alive at the end of the game, but have not hit their win condition will still lose.


### PR DESCRIPTION
Replace with:
> An exception is Unaligned players, the werewolves do not need to kill them, however any Unaligned player that remains alive at the end of the game, but has not hit their win condition will still lose.