### PR TITLE
Make Idiot consistent

### DIFF
--- a/_rules/attacks/3 blocks
+++ b/_rules/attacks/3 blocks
@@ -1,5 +1,5 @@
 **Blocks**
-There's several ways an attack (or kill) can be stopped. These sort of abilities/effects are applied in the following order:
+There are several ways an attack (or kill) can be stopped. These sort of abilities/effects are applied in the following order:
 
 1) Absences (such as hooker)
 2) Effect Based Defenses (such as the witch's potion of life or the chef's charmed food)
@@ -8,4 +8,4 @@ There's several ways an attack (or kill) can be stopped. These sort of abilities
 5) Role Based Role Changes (such as Cursed Civilian)
 6) Effect Based Role Changes (such as vampire's demonization)
 
-For both attacks and direct kills all six points apply, however most defensive abilities only apply to attacks, and not kills.
+For both attacks and direct kills all six points apply, though most defensive abilities apply only to attacks.

--- a/_rules/attacks/3 blocks
+++ b/_rules/attacks/3 blocks
@@ -1,5 +1,5 @@
 **Blocks**
-There's several ways an attack can be stopped. These sort of abilities/effects are applied in the following order:
+There's several ways an attack (or kill) can be stopped. These sort of abilities/effects are applied in the following order:
 
 1) Absences (such as hooker)
 2) Effect Based Defenses (such as the witch's potion of life or the chef's charmed food)
@@ -8,4 +8,4 @@ There's several ways an attack can be stopped. These sort of abilities/effects a
 5) Role Based Role Changes (such as Cursed Civilian)
 6) Effect Based Role Changes (such as vampire's demonization)
 
-If a player is attacked, all points apply. If a player is killed or dies, the first four points are skipped, and only role changes can still stop the death.
+For both attacks and direct kills all six points apply, however most defensive abilities only apply to attacks, and not kills.

--- a/townsfolk/miscellaneous/idiot
+++ b/townsfolk/miscellaneous/idiot
@@ -2,7 +2,7 @@
 __Basics__
 If the Idiot dies for the first time, they instead live, but lose their voting power.
 __Details__ 
-If the Idiot dies due to the lynch or due to an attack, the first death will be prevented.
+The first time the Idiot is lynched, attacked or killed, they will survive.
 However, the Idiot loses their vote and is informed about this.
 If the Idiot is Mayor, they will still have their Mayor vote.
 


### PR DESCRIPTION
Fix #685 

The issue is that blocks claim that kills skip the first 4 block types, when that contains the category of the Idiot's defense. To fix this we can actually just remove that part. Pretty much all the defenses already state that they exclusively defend against attacks (and not kills) so skipping them with kills makes no functional difference. There's also some other things that aren't quite clear, so I'd define the following:

- Attack - an attempted kill that can be blocked by a variety of defense, possibly results in a death
- Kill - a kill that is much more difficult to block, a negative outcome is guaranteed (even if it is not death), usually results in a death
- Lynch - an attempted kill that can only be stopped using very specific powers, usually results in a death
- Death - the result of an attack/kill/lynch