### PR TITLE
Nonaligned edit

### DIFF
--- a/_categories/unaligned
+++ b/_categories/unaligned
@@ -1,2 +1,1 @@
-Unaligned roles are not part of any other team when the game starts. Some of these roles align themselves with one of the other teams during the game, while others can win with any team.
-Any team can win if their win condition is fulfilled with the exception of all the Unaligned players.
+Unaligned roles can, by default, win with any other team. Some may maintain this status throughout the game (nonaligned roles): others can develop alignments, preventing them from winning with certain teams.

--- a/_categories/unaligned align
+++ b/_categories/unaligned align
@@ -1,1 +1,1 @@
-'Unaligned Align' are those unaligned roles that join a team (become aligned) at some point in the game.
+'Unaligned Align' are those unaligned roles that can develop alignments without being converted or recruited.

--- a/_categories/unaligned align - cupid
+++ b/_categories/unaligned align - cupid
@@ -1,2 +1,2 @@
 'Unaligned Align - Cupid' roles are a subcategory of the unaligned align roles. The only Cupid that can exist at the start of the game is the plain Cupid. Cupids are considered a part of the Unaligned Align category, but are listed separately to avoid confusion.
-All Cupids can never change roles, except to another Cupid variant. Cupids have a base alignment, which is combined with the base alignment of their lover to form their actual alignment.
+All Cupids can never change roles except to other Cupid variants. Cupids are originally nonaligned, and will acquire the alignment of their lover.

--- a/_categories/unaligned align - hag
+++ b/_categories/unaligned align - hag
@@ -1,3 +1,3 @@
-'Unaligned Align - Hag' roles are a subcategory of the unaligned align roles. Hags are considered a part of the Unaligned Align category, but are listed separately to avoid confusion.
+'Unaligned Align - Hag' roles are a subcategory of the unaligned align roles. Hags are originally coven-acquired, and acquire alignments when they are wronged. Hags are considered a part of the Unaligned Align category, but are listed separately to avoid confusion.
 
-IMPORTANT: Hags are currently still considered to be limited roles, however they are listed here due to technical reasons.
+IMPORTANT: Hags are currently still considered to be limited roles: they are listed here due to technical reasons.

--- a/_categories/unaligned align - hag
+++ b/_categories/unaligned align - hag
@@ -1,3 +1,3 @@
-'Unaligned Align - Hag' roles are a subcategory of the unaligned align roles. Hags are originally coven-acquired, and acquire alignments when they are wronged. Hags are considered a part of the Unaligned Align category, but are listed separately to avoid confusion.
+'Unaligned Align - Hag' roles are a subcategory of the unaligned align roles. Hags are originally coven-aligned, and acquire alignments when they are wronged. Hags are considered a part of the Unaligned Align category, but are listed separately to avoid confusion.
 
 IMPORTANT: Hags are currently still considered to be limited roles: they are listed here due to technical reasons.

--- a/_rules/alignments/4 unaligned
+++ b/_rules/alignments/4 unaligned
@@ -1,4 +1,3 @@
 **Unaligned**
-The unaligned are truly unique, they aren't part of any alignment. They make up about 10% of the players. Their goal is to fulfill their win condition. With that, they might even join an alignment. 
-The ones that don't change alignment ascend when they win. As they have no alignment, they are free to work with whatever alignment they want.
-Unaligned players are exempt from other teams' win conditions. For example, this means that the Werewolves can win with Unaligned players left alive, even though they are supposed to kill all other players. This does not apply for Unaligned players that join an alignment or can't win with every alignment.
+The Unaligned are by default able to win with any other team. They make up about 10% of the players. Their goal is to fulfill their win condition. Many Unaligned roles are nonaligned, but some can acquire alignments.
+Unaligned players are exempt from other teams' win conditions. For example, the Werewolves can win with Unaligned players left alive, even though they are supposed to kill all other players. This includes Unaligned players who have alignments, but not players who were previously Unaligned but have since changed role to one that is not Unaligned.

--- a/limited/detective
+++ b/limited/detective
@@ -4,6 +4,7 @@ During the day, the detective compiles information on other players. At night, t
 __Details__
 Each day, the detective has to choose between guessing one player's current role or learning the final role of a dead player. If they guess a player's current role correctly, it is confirmed. The detective is not affected by any disguises, obstructions or redirections.
 Each night, the detective must try to submit the contents (players and their roles) of the entire initial role list in their secret channel. If their guess is correct, they ascend and win the game. If their guess is wrong, they are informed how many guesses (but not which) were correct. The Detective may also only submit a partial list, however they cannot win if they do so.
+The Detective is nonaligned.
 
 __Simplified__
 The Detective wins by figuring out the original roles of all players, however the game continues afterwards.

--- a/limited/rival
+++ b/limited/rival
@@ -7,7 +7,8 @@ The Rival can only exist with another rival in the game. The Rival ascends when 
 Every night after Night 1, the Rival can investigate a player and will learn their role.
 The Rival is affected by weak disguises, obstructions and redirections. They are told specifically if an investigation was affected by a disguise, an obstruction, or a redirection - if it was unaffected, they are informed of this too.
 If the win condition of the Rival changes in any way, they do not require the other Rival to die. 
-If the win condition or role of another Rival changes in any way, the Rival still requires any other (original) Rivals to die. 
+If the win condition or role of another Rival changes in any way, the Rival still requires any other (original) Rivals to die.
+The Rival is nonaligned.
 
 __Simplified__
 Every night after Night 1, the Rival can investigate a player and will learn their role. 

--- a/townsfolk/investigative/oracle
+++ b/townsfolk/investigative/oracle
@@ -4,7 +4,7 @@ Every night, the Oracle can select two players and see if they have the same ali
 __Details__
 Each night, the Oracle can inspect two players. The Oracle will be told whether they have the same alignment. 
 The Oracle can select itself as one of the two players, but can only select each player once throughout the game. 
-Inspecting players is an immediate ability. Unaligned roles (if they are still unaligned) have the same alignment as each other: solo roles on opposing teams do not.
+Inspecting players is an immediate ability. Nonaligned roles have the same alignment as each other: roles with differing alignments do not. A nonaligned role does not have the same alignment as an aligned role.
 Some unaligned roles may gain alignments during the game (e.g. Cupid).
 The Oracle is not affected by disguises or obstructions, but is affected by redirections.
 

--- a/unaligned/align - cupid/cupid
+++ b/unaligned/align - cupid/cupid
@@ -11,7 +11,8 @@ After choosing a lover, unless they are also unaligned, the Cupid is no longer u
 If a Cupid couple ends up without a win condition (e.g. two Cupids falling in love with each other), their goal is to survive until the end of the game and win with whatever team remains.
 If the Cupid loses their role before selecting a lover, a random lover is chosen immediately.
 The Cupid can never change role to anything but another cupid variant (more info in `$info cupid variants`).
-If the Cupid's lover is part of a solo team or channel then the Cupid is immune to that team's effects or their consequences (e.g powdering, death by plague, sleepless, etc)
+If the Cupid's lover is part of a solo team or channel then the Cupid is immune to that team's effects or their consequences (e.g powdering, death by plague, sleepless, etc).
+The Cupid is nonaligned unless they gain an alignment via falling in love or becoming a cupid variant with an alignment.
 
 __Simplified__
 The Cupid chooses one player to become their lover. They can never betray each other and if one dies, the other does too. The Cupid's alignment is the same as their lover's alignment.

--- a/unaligned/align - cupid/cupid
+++ b/unaligned/align - cupid/cupid
@@ -12,7 +12,7 @@ If a Cupid couple ends up without a win condition (e.g. two Cupids falling in lo
 If the Cupid loses their role before selecting a lover, a random lover is chosen immediately.
 The Cupid can never change role to anything but another cupid variant (more info in `$info cupid variants`).
 If the Cupid's lover is part of a solo team or channel then the Cupid is immune to that team's effects or their consequences (e.g powdering, death by plague, sleepless, etc).
-The Cupid is nonaligned unless they gain an alignment via falling in love or becoming a cupid variant with an alignment.
+The Cupid is nonaligned unless they gain an alignment from their lover.
 
 __Simplified__
 The Cupid chooses one player to become their lover. They can never betray each other and if one dies, the other does too. The Cupid's alignment is the same as their lover's alignment.

--- a/unaligned/align - cupid/cupid hag
+++ b/unaligned/align - cupid/cupid hag
@@ -5,6 +5,7 @@ __Details__
 If the cupid selects a lover that is a hag or if their lover turns into a hag, the cupid turns into a Cupid Hag, but may lose their role again at a later point.
 The Cupid Hag works like the cupid, with several exceptions: The Cupid Hag is strongly disguised as a hag, and can be wronged like any other hag.
 If the hags turn into bitter hags, the Cupid Hag joins the bitter hag channel, and shares their win condition.
+The Cupid Hag is coven-aligned.
 
 __Simplified__
 The Cupid Hag is a cupid whose lover is a member of the coven team.

--- a/unaligned/align - cupid/cupid variants
+++ b/unaligned/align - cupid/cupid variants
@@ -1,8 +1,8 @@
 **Cupid Variants**
-The Cupid can never change role to a role that isn't a cupid variant. Every time the Cupid would usually change role, they instead change to a different cupid variant. After picking a lover, or if the lover changes alignment, the cupid may also change role. The following cupid variants exist.
+The cupid can never change role to a role that isn't a Cupid Variant. Every time the cupid would usually change role, they instead change to a different Cupid Variant. After picking a lover, or if the lover changes alignment, the cupid may also change role. The following Cupid Variants exist.
 
 __Cupid__
-This is the default cupid role, and the only one that can be in a role list. Unless another case applies the cupid stays as this role.
+This is the default cupid role, and the only one that can be in a role list. Unless another case applies, the cupid stays as this role.
 
 __Cupid Wolf__
 If the cupid is targetted by the infecting wolf, they turn into a cupid wolf instead of a normal wolf.
@@ -14,7 +14,7 @@ __Spectral Cupid__
 If the cupid is recruited onto the nightmare team, they turn into a spectral cupid instead of into a spirit.
 
 __Demonic Cupid__
-If the cupid's lover is a member of hell, the cupid becomes a demonic cupid, and a full member of hell. Afterwards, the cupid cannot change role again.
+If the cupid's lover is a member of the hell team, the cupid becomes a demonic cupid and a full member of hell. Afterwards, the cupid cannot change role again.
 
 __Cupid Hag__
 If the cupid's lover is a hag, the cupid becomes a cupid hag. The cupid hag shares the win condition of the hags and can be wronged.

--- a/unaligned/align - cupid/cupid wolf
+++ b/unaligned/align - cupid/cupid wolf
@@ -4,6 +4,7 @@ The Cupid Wolf is a cupid that has been infected by the infected wolf.
 __Details__
 If turned into a wolf in any way, the cupid turns into an Cupid Wolf instead. 
 The Cupid Wolf works like the cupid, with one exception: they are part of the wolfpack group.
+The Cupid Wolf is nonaligned, unless it has gained an alignment from falling in love.
 
 __Simplified__
 The Cupid Wolf is a cupid that has been infected by the infected wolf.

--- a/unaligned/align - cupid/cupid wolf
+++ b/unaligned/align - cupid/cupid wolf
@@ -4,7 +4,7 @@ The Cupid Wolf is a cupid that has been infected by the infected wolf.
 __Details__
 If turned into a wolf in any way, the cupid turns into an Cupid Wolf instead. 
 The Cupid Wolf works like the cupid, with one exception: they are part of the wolfpack group.
-The Cupid Wolf is nonaligned, unless they have gained an alignment from falling in love.
+The Cupid Wolf is nonaligned, unless they have gained an alignment from their lover.
 
 __Simplified__
 The Cupid Wolf is a cupid that has been infected by the infected wolf.

--- a/unaligned/align - cupid/cupid wolf
+++ b/unaligned/align - cupid/cupid wolf
@@ -4,7 +4,7 @@ The Cupid Wolf is a cupid that has been infected by the infected wolf.
 __Details__
 If turned into a wolf in any way, the cupid turns into an Cupid Wolf instead. 
 The Cupid Wolf works like the cupid, with one exception: they are part of the wolfpack group.
-The Cupid Wolf is nonaligned, unless it has gained an alignment from falling in love.
+The Cupid Wolf is nonaligned, unless they have gained an alignment from falling in love.
 
 __Simplified__
 The Cupid Wolf is a cupid that has been infected by the infected wolf.

--- a/unaligned/align - cupid/demonic cupid
+++ b/unaligned/align - cupid/demonic cupid
@@ -2,10 +2,10 @@
 __Basics__
 The Demonic Cupid is a cupid whose lover is a member of the hell team.
 __Details__
-If the cupid selects a lover from the hell team or if their lover joins the hell team, the cupid turns into a Demonic Cupid.
-The Demonic Cupid works like the cupid, with a few exceptions: The Demonic Cupid's alignment is hell.
+If the cupid selects a lover from the hell team, or if their lover joins the hell team, the cupid turns into a Demonic Cupid.
+The Demonic Cupid works like the cupid, with one exception: he Demonic Cupid's alignment is hell.
 Once a cupid and their lover have joined the hell team, they cannot betray the team in any way. Any attempts at conversion of a member will fail in some manner.
-If the cupid has a soul it is lost the moment they become a Demonic Cupid. The hell team gains this soul for their pool of souls.
+If the cupid has a soul then it is lost the moment they become a Demonic Cupid. The hell team gains this soul for their pool of souls.
 
 __Simplified__
 The Demonic Cupid is a cupid whose lover is a member of the hell team. The Demonic Cupid's alignment is hell.

--- a/unaligned/align - cupid/spectral cupid
+++ b/unaligned/align - cupid/spectral cupid
@@ -4,7 +4,7 @@ The Spectral Cupid is a cupid that has been recruited onto the nightmare team.
 __Details__
 Instead of turning into a spirit, the cupid turns into an Spectral Cupid. 
 The Spectral Cupid works like the cupid, with one exception: they are part of the nightmare group.
-The Spectral Cupid is nonaligned, unless they have gained an alignment from falling in love.
+The Spectral Cupid is nonaligned, unless they have gained an alignment from their lover.
 
 __Simplified__
 The Spectral Cupid is a cupid that has been recruited onto the nightmare team.

--- a/unaligned/align - cupid/spectral cupid
+++ b/unaligned/align - cupid/spectral cupid
@@ -4,6 +4,7 @@ The Spectral Cupid is a cupid that has been recruited onto the nightmare team.
 __Details__
 Instead of turning into a spirit, the cupid turns into an Spectral Cupid. 
 The Spectral Cupid works like the cupid, with one exception: they are part of the nightmare group.
+The Spectral Cupid is nonaligned, unless they have gained an alignment from falling in love.
 
 __Simplified__
 The Spectral Cupid is a cupid that has been recruited onto the nightmare team.

--- a/unaligned/align - cupid/undead cupid
+++ b/unaligned/align - cupid/undead cupid
@@ -4,6 +4,6 @@ The Undead Cupid is a cupid that has been demonized and then killed.
 __Details__
 Instead of turning into an undead, the cupid turns into an Undead Cupid. 
 The Undead Cupid works like the cupid, with one exception: they are part of the underworld group.
-
+The Undead Cupid is nonaligned, unless they have gained an alignment from their lover.
 __Simplified__
 The Undead Cupid is a cupid that has been demonized and then killed.

--- a/unaligned/align - cupid/undead cupid
+++ b/unaligned/align - cupid/undead cupid
@@ -5,5 +5,6 @@ __Details__
 Instead of turning into an undead, the cupid turns into an Undead Cupid. 
 The Undead Cupid works like the cupid, with one exception: they are part of the underworld group.
 The Undead Cupid is nonaligned, unless they have gained an alignment from their lover.
+
 __Simplified__
 The Undead Cupid is a cupid that has been demonized and then killed.

--- a/unaligned/align - hag/bitter hag
+++ b/unaligned/align - hag/bitter hag
@@ -1,6 +1,6 @@
 **Bitter Hag** | Solo Killing - Coven Team | Limited Transformation
 __Basics__
-If the hags have been wronged by all remaining teams, they turn into Bitter Hags. The Bitter Hag wins if all remaining players are dead, nonaligned, or coven-aligned. The Bitter Hag may use each of the hag spells every night.
+If the hags have been wronged by all remaining teams, they turn into Bitter Hags. The Bitter Hag wins if all remaining players are dead, unaligned, or coven-aligned. The Bitter Hag may use each of the hag spells every night.
 __Details__
 When hags become Bitter Hags, they gain a new secret channel with any other Bitter Hags. Each Bitter Hag may protect, investigate and attack a player every night. Any remaining spells prior to becoming Bitter Hag are not preserved.
 The spells of the Bitter Hag work like the spells of the cautious, vicious and prophetic hags and are not affected by any disguises, redirections or obstructions.

--- a/unaligned/align - hag/bitter hag
+++ b/unaligned/align - hag/bitter hag
@@ -1,12 +1,12 @@
 **Bitter Hag** | Solo Killing - Coven Team | Limited Transformation
 __Basics__
-If the hags have been wronged by all remaining teams, they turn into Bitter Hags. The Bitter Hag wins if all remaining players are dead, unaligned or hags. The Bitter Hag may use each of the hag spells every night.
+If the hags have been wronged by all remaining teams, they turn into Bitter Hags. The Bitter Hag wins if all remaining players are dead, nonaligned, or coven-aligned. The Bitter Hag may use each of the hag spells every night.
 __Details__
-When hags become Bitter Hags they gain a new secret channel with the other Bitter Hags (if there are any). Each Bitter Hag may protect, investigate and attack a player every night. However, if their previous spell had any uses left, they do not get to keep these upon changing to Bitter Hag.
-The spells of the Bitter Hag work like the spells of the cautious, vicious and prophetic hag and are not affected by any disguises, redirections or obstructions.
-The Bitter Hag cannot be part of role lists and can only be created by a hag turning into it.
-Sometimes, hags may turn into Bitter Hags directly after wronging (if they are wronged by the last remaining team that hasn't wronged them), however they may also turn into Bitter Hags if the last remaining team that hasn't wronged them is eliminated, leaving only teams that have wronged the hags. 
+When hags become Bitter Hags, they gain a new secret channel with any other Bitter Hags. Each Bitter Hag may protect, investigate and attack a player every night. Any remaining spells prior to becoming Bitter Hag are not preserved.
+The spells of the Bitter Hag work like the spells of the cautious, vicious and prophetic hags and are not affected by any disguises, redirections or obstructions.
+The Bitter Hag cannot be part of role lists and can only be created by a hag becoming one.
 The Bitter Hag is strongly disguised as a Hag.
+The Bitter Hag is coven-aligned.
 
 __Simplified__
 If the hags have been wronged by all remaining teams, they turn into Bitter Hags. The Bitter Hag wins if all remaining players are dead, unaligned or hags. Each Bitter Hag may protect, investigate and attack a player once per night.

--- a/unaligned/align - hag/cautious hag
+++ b/unaligned/align - hag/cautious hag
@@ -1,13 +1,14 @@
 **Cautious Hag** | Unaligned Power | Limited
 __Basics__
-The Cautious Hag can win with any team, unless that team has wronged the coven, however the Cautious Hag cannot win if the coven has never been wronged.
+The Cautious Hag can win with any team, unless that team has wronged the coven: however, the Cautious Hag cannot win if the coven has never been wronged.
 The Cautious Hag can protect a player.
 __Details__
 The Cautious Hag is one of the hags (`$i hags`).
-During the night, the Cautious Hag may use any number of their spell(s) to protect a player(s). The Cautious Hag may protect themself. This power is not affected by redirections. 
+During the night, the Cautious Hag may use any quantity of their spells to protect players. The Cautious Hag may protect themself. This power is not affected by redirections. 
 Protecting a player is an immediate ability. Protected players will be immune to attacks for the rest of the night. If the protected player is a hag, they can also not be affected by any other action that is counted as “wronging” (e.g. Transformations).
 The Cautious Hag is strongly disguised as a Hag.
+The Cautious Hag is coven-aligned.
 
 __Simplified__
 The Cautious Hag is one of the hags and can win with any team that hasn't wronged the coven, but cannot win if they have never been wronged.
-The Cautious Hag may once protect a player, including themself.
+The Cautious Hag may protect a player, including themself.

--- a/unaligned/align - hag/hag
+++ b/unaligned/align - hag/hag
@@ -1,12 +1,13 @@
 **Hag** | Unaligned Miscellaneous | Limited
 __Basics__
-The Hag can win with any team, unless that team has wronged the coven, but cannot win if the coven has never been wronged.
+The Hag can win with any team, unless that team has wronged the coven: however, they cannot win if the coven has never been wronged.
 The Hag will turn into a specific type of hag at the end of the day.
 __Details__
 The Hag is one of the hags (`$i hags`).
 At the start of the game, the Hag may discard one hag role (vicious, cautious or prophetic). 
 At the end of the day, the Hag turns into an undiscarded hag role.
-The Hag does not have a spell at the start of the game, but gains one later, once they turn into another hag role.
+The Hag does not have a spell at the start of the game, but gains one once they turn into another hag role.
+The Hag is coven-aligned.
 
 __Simplified__
 The Hag can win with any team, unless that team has wronged the coven, but cannot win if they have never been wronged.

--- a/unaligned/align - hag/hags
+++ b/unaligned/align - hag/hags
@@ -1,6 +1,7 @@
 **The Hags** | Additional Information | Limited
 __General__
 The Hags do not know each other, but always have the same win condition and alignment. Unlike other unaligned roles, Hags can win while dead, as long as one Hag survives.
+All Hags are always coven-aligned: their wronging by another team also causes them to align against that team.
 
 __Win Conditions__
 At the start of the game, the Hags cannot win. Once they have been wronged by a team, they can win with any team that hasn't wronged the coven.

--- a/unaligned/align - hag/prophetic hag
+++ b/unaligned/align - hag/prophetic hag
@@ -7,7 +7,8 @@ The Prophetic Hag is one of the hags (`$i hags`).
 During the night, the Prophetic Hag may use any quantity of their spells to see the alignment of other players. This check is not affected by any disguises, obstructions or redirections.
 Checking a player is an immediate ability.
 The Prophetic Hag is strongly disguised as a Hag.
+The Prophetic Hag is coven-aligned.
 
 __Simplified__
 The Prophetic Hag is one of the hags and can win with any team that hasn't wronged the coven, but cannot win if they have never been wronged.
-The Prophetic Hag may once check a player's alignment.
+The Prophetic Hag may check a player's alignment.

--- a/unaligned/align - hag/vicious hag
+++ b/unaligned/align - hag/vicious hag
@@ -1,12 +1,13 @@
 **Vicious Hag** | Unaligned Killing | Limited
 __Basics__
-The Vicious Hag can win with any team, unless that team has wronged the coven, however the Vicious Hag cannot win if the coven has never been wronged.
+The Vicious Hag can win with any team, unless that team has wronged the coven: however, the Vicious Hag cannot win if the coven has never been wronged.
 The Vicious Hag can attack another player.
 __Details__
 The Vicious Hag is one of the hags (`$i hags`).
-During the night, the Vicious Hag may use any number of their spell(s) to attack another player(s). This power is not affected by redirections.
+During the night, the Vicious Hag may use any quantity of their spells to attack other players. This power is not affected by redirections.
 Attacking a player is an end-night ability.
 The Vicious Hag is strongly disguised as a Hag.
+The Vicious Hag is coven-aligned.
 
 __Simplified__
 The Vicious Hag is one of the hags and can win with any team that hasn't wronged the coven, but cannot win if they have never been wronged.

--- a/unaligned/align/cat
+++ b/unaligned/align/cat
@@ -6,6 +6,7 @@ If the dog chooses fortune teller, the Cat will turn into warlock, and vice vers
 Changing role is an immediate consequence of the dog choosing. A Cat which becomes a fortune teller or a warlock may not use that role's investigation during Night 1.
 For each Cat in the game, there must be a corresponding dog. Neither player will know their counterpart.
 The Cat is strongly disguised as Cat: this will persist despite any role changes.
+The Cat is nonaligned until it changes role.
 
 __Simplified__
 For each Cat, there is a corresponding dog. The Cat will become the opposite of the role the dog chose.

--- a/unaligned/align/dog
+++ b/unaligned/align/dog
@@ -6,6 +6,7 @@ Choosing a role is an immediate ability. If the Dog hasn’t chosen a role befor
 If there is a cat corresponding to the Dog, the unaligned role the Dog may become is rival - otherwise, it is psychopath.
 A Dog which becomes a fortune teller or a warlock may not use that role's investigation during Night 1.
 The Dog is strongly disguised as Dog: this persists despite role changes.
+The Dog is nonaligned until it changes role.
 
 __Simplified__
 During Night 1, the Dog may choose between fortune teller, warlock, and either rival or psychopath. It will immediately become this role for the rest of the game.

--- a/unaligned/investigative/psychopath
+++ b/unaligned/investigative/psychopath
@@ -1,12 +1,13 @@
 **Psychopath** | Unaligned Investigative
 __Basics__
-At the start of the game, the Psychopath is given an arbitrary list with one third of the town’s population, rounded up, on it. If all players on that list are dead, and the Psychopath is still alive, the Psychopath wins.
+At the start of the game, the Psychopath is given a list with one third of the game's players, rounded up, on it. If all players on the list are dead, and the Psychopath is still alive, the Psychopath wins.
 __Details__
 When the Psychopath wins, the Psychopath ascends and stops playing. The game continues. The Psychopath can’t win when they are dead. 
-The Psychopath's list will always contain at least one player from every team that has at least two players.
+The Psychopath's list will always contain at least one player from every team that has at least two players. Which players are on the list is determined arbitrarily.
 The Psychopath may strongly disguise themself as any role. The disguise is applied immediately. They can update this disguise once per phase, with 1 emergency change to be used whenever the Psychopath wants to. If the Psychopath changes role, the disguise is lost.
-Additionally, the Psychopath may choose to either investigate or weakly disguise a player each day, but not both. Their investigation is affected by all disguises, redirections and obstructions. Their disguise lasts for the current and next phase.
+Additionally, the Psychopath may choose to either investigate or weakly disguise a player each day, but not both. Their investigation is affected by all disguises, redirections and obstructions. Their disguise lasts for the current and following phase.
+The Psychopath is nonaligned.
 
 __Simplified__
-The Psychopath has a list with 1/3rd of all the players on it. If all players on that list are dead, the Psychopath wins and stops playing. The game continues.
+The Psychopath has a list with one third of all the players on it. If all players on that list are dead, the Psychopath wins and stops playing. The game continues.
 The Psychopath is strongly disguised as a role of their choosing. Additionally, they may either investigate or weakly disguise others each day.

--- a/unaligned/killing/angel
+++ b/unaligned/killing/angel
@@ -2,12 +2,12 @@
 __Basics__
 The Angel wins when they are lynched.
 __Details__
-When the Angel wins, the Angel ascends and stops playing and the game continues. In addition, the following lynch will be canceled.
-The Angel may select a player that dies when the Angel is lynched, if this player has voted for the Angel when the Angel is lynched, it is announced and they will also die. 
+When the Angel wins, the Angel ascends and stops playing. The game continues. In addition, the following lynch will be cancelled.
+The Angel may select a player. If this player has voted for the Angel when the Angel is lynched, they will also die. If the Angel has not selected a target, or the selected target did not vote for and did not apply any invisible votes on the Angel, a random player who did vote for the Anegl will die instead. The cause of their death is announced.
+If the Angel is lynched by unusual means (e.g. by the invisible Stalker votes or the Executioner selecting them) the player responsible for this will die with the Angel in place of the chosen target. If nobody except the Angel has voted for the Angel, the Angel dies and does not win.
 The Angel may change their target once per phase, with 1 emergency change to be used whenever the Angel wants to. The Angel cannot select themself. Targetting a player is an immediate effect. The Angel may choose to target nobody.
-If they haven’t selected a (valid) target, a random player that has voted for the Angel is selected instead. If the Angel is lynched by unusual means (e.g. by the invisible Stalker votes or the Executioner selecting them) the player responsible for this will die with the Angel. If nobody except the Angel has voted for the Angel, the Angel dies and does not win.
-If the Angel's target didn't vote for the Angel, but did put invisible votes on the Angel, they are considered a valid target.
+The Angel is nonaligned.
 
 __Simplified__
-The Angel wins when they are lynched, however the game continues afterwards. In addition, the following lynch will be canceled.
+The Angel wins when they are lynched: the game continues afterwards. In addition, the following lynch will be cancelled.
 The Angel may select a player that dies when the Angel is lynched, but only if the target is voting for the Angel. 

--- a/unaligned/killing/chef
+++ b/unaligned/killing/chef
@@ -11,6 +11,7 @@ If a new solo team is created during the game, they do not gain a waiter. If a w
 When the last waiter dies, the Chef stops playing, descends and loses.
 The Chef may not select themself as customer.
 The Chef is not affected by redirections.
+The Chef is nonaligned.
 
 __Simplified__
 The Chef has one waiter from every team, and their goal is to keep at least one alive. When the last waiter dies, the Chef dies and loses.

--- a/unaligned/miscellaneous/despot
+++ b/unaligned/miscellaneous/despot
@@ -1,8 +1,9 @@
 **Despot** | Unaligned Miscellaneous
 __Basics__
-If the Despot is elected, they win. The next day, the election will be skipped.
+If the Despot is elected, they win. The next day, the election will be cancelled.
 __Details__
 When the Despot wins, the Despot ascends and stops playing. The game continues.
+The Despot is nonaligned.
 
 __Simplified__
-If the Despot is elected, they win and stop playing, but the game still continues. The next day, the election will be skipped.
+If the Despot is elected, they win and stop playing, but the game still continues. The next day, the election will be cancelled.

--- a/unaligned/miscellaneous/riding hood
+++ b/unaligned/miscellaneous/riding hood
@@ -3,11 +3,12 @@ __Basics__
 The Riding Hood wins when they are killed by a wolfish player.
 __Details__
 When the Riding Hood wins, the Riding Hood ascends and stops playing. The game continues.
-The Riding Hood will win if they are killed by a wolfish player. If the Riding Hood is killed in another way, they lose. 
-If the Riding Hood is protected they neither die nor do they ascend. When the Riding Hood is killed by the wolfpack, the wolfpack may not attack *anyone* the following night.
-When the Riding Hood ascends any other way, the wolfish player responsible will be unable to kill/attack the following night.
+The Riding Hood will win if they are killed by a wolfish player. If the Riding Hood is killed in another way, they lose. If the Riding Hood is protected they neither die nor ascend. 
+When the Riding Hood is killed by the wolfpack, the wolfpack may not attack *anyone* the following night.
+When the Riding Hood ascends any other way, the wolfish player responsible will be unable to kill or attack the following night.
 If no wolfish players remain, the Riding Hood stops playing, descends and loses.
+The Riding Hood is nonaligned.
 
 __Simplified__
-The Riding Hood wins when they are killed by a werewolf. They then stop playing, but the game continues. In the following night, the wolfpack cannot kill.
+The Riding Hood wins when they are killed by a werewolf. They then stop playing, but the game continues. During the following night, the werewolf responsible cannot kill.
 If they are killed in another way, they lose.


### PR DESCRIPTION
This revamp creates a vocabulary distinction between unaligned (those roles which can win with any team by default) and nonaligned (those roles without alignments). All nonaligned roles are unaligned, but not all unaligned roles are nonaligned: cupids almost always acquire alignments, and hags are coven-aligned rather than nonaligned.

The edits to the roles specify whether unaligned roles are nonaligned or not (except in the case of Oracle). The edits to the _categories and _rules descriptions specify the differences between unalignment and nonalignment. There are also several instances of clarifications and grammar corrections within descriptions, and one case where something that should have been pushed in a previous patch was not included.

This revamp contains only one significant mechanical change: an Oracle will now not see Hags or aligned Cupids as sharing an alignment with nonaligned roles. Hags will still show as aligned with other hags, and aligned Cupids will show as aligned with those who share their lover's alignment.