### PR TITLE
Update Guardian to match Mayor

### DIFF
--- a/extra/elected/guardian
+++ b/extra/elected/guardian
@@ -16,6 +16,9 @@ The Guardian is elected when there is a Mayor and a Reporter. Each night, they m
 __Formalized__
 Starting: Set Counter to ceil $total/1.5 for @ThisAttr
 Immediate Night: Protect @Selection from `Attacks` through Active Defense (~Phase) [Succession: No Target Succession] ⟨x1, $living > @ThisAttr->Counter ⇒ x2⟩
+Passive End Phase: [Attribute: @ThisAttr lacks `Marker`, Condition: not ($living > @ThisAttr->Counter)]
+  • Announce `Guardian may only protect 1 person now`
+  • Apply `Marker` to @ThisAttr
 End Phase: {Vanishing} |silent:granting.resign|
   • Announce `@Self resigned as Guardian`
   • Revoke @ThisAttr from @Self


### PR DESCRIPTION
This brings the guardians' power check in line with the mayor by using the same ratio of alive players.