### PR TITLE
Wager Recipient Prompts

### DIFF
--- a/other/hell/devil
+++ b/other/hell/devil
@@ -40,18 +40,18 @@ Start Night: [Attribute: @Selection lacks `Soulless`] {Direct} |devil.1|
   • Grant `Wager Recipient` to @Selection
   • Whisper to `Wager Recipient` as `Devil` (~Phase)
   • `Wager` Choice Creation for `Wager Recipient` (Attack, Protect, Investigate, Ignore)
-Choice `Attack` Chosen:
+Choice `Attack` Chosen: |wager.2|
   • Apply `Soulless` to @Chooser (~Persistent)
   • Increment Counter for #hell  
   • Target @Selection (Player)
   • Apply `Marker` to @Self
   • Reveal `Attacking @Selection` to @Self
-Choice `Protect` Chosen:
+Choice `Protect` Chosen: |wager.3|
   • Apply `Soulless` to @Chooser (~Persistent)
   • Increment Counter for #hell  
   • Protect @Selection from `Attacks` through Active Defense (~Phase)
   • Reveal `Protecting @Selection` to @Self
-Choice `Investigate` Chosen:
+Choice `Investigate` Chosen: |wager.4|
   • Process: Role Investigate @Selection (WD, SD)
   • Evaluate:
     ‣ Reveal `@Selection is @Result->Role` to `Wager Recipient`


### PR DESCRIPTION
Add additional WR prompts

These need to be added to bot:
"wager.2": "You have chosen to attack a player who still has a soul, but sell your soul in the process. Please select a player.",
"wager.3": "You have chosen to protect yourself or any player, but sell your soul in the process. Please select a player.",
"wager.4": "You have chosen to check someone's role, but the Devil will see the result and also your role. Please select a player.",