### PR TITLE
Fix Fletcher's Customer knowing Fletcher death

### DIFF
--- a/extra/killing/fletchers customer
+++ b/extra/killing/fletchers customer
@@ -14,9 +14,8 @@ The Fletcher's Customer is an extra role that doesn't replace the player's curre
 __Formalized__
 Immediate: Target @Selection (Player Optional) [Condition: not (@Target exists)] |targeting.target.player|
 Immediate: Target @Selection (Player Optional) [Condition: @Target exists] |silent:targeting.change.player|
-Immediate: Target @Selection (Player) |silent:targeting.target.player|
 On Action [Targeting]: Target @Selection (Player) [Quantity: 1] |silent:targeting.emergency.player|
-On Killed: [Condition: @Target exists]
+On Killed: [Condition: @Target exists, Condition: @ThisAttr->Source is part of @All]
   • Process: Attack @Target
   • Evaluate: @Result is `Success`: Announce `Fletcher's Customer @Self killed @Target`
 

--- a/townsfolk/power/fletcher
+++ b/townsfolk/power/fletcher
@@ -14,7 +14,6 @@ __Formalized__
 Immediate Day: [Quantity: 1, Temporal: Day 0, Condition: @Selection is not @Self] {Forced}
   • Grant `Fletcher's Customer` to @Selection
   • Target @Selection (Player)
-On Death: Revoke `Fletcher's Customer` from @Target [Temporal: Night 1+, Condition: @Target exists]
 
 __Card__
 The Fletcher likes to gift their handmade bows and arrows to those they trust.


### PR DESCRIPTION
FC can now no longer tell when Fletcher dies based on when the ability is revoked

Instead FC actively checks if Fletcher is still alive when it kills

Fixes https://github.com/WerewolvesRevamped/Werewolves-Roles/issues/1591